### PR TITLE
no-abort: rust functions

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1113,17 +1113,17 @@ fn expand_rust_function_shim_impl(
         }
     };
 
-    let mut outparam = None;
-    let indirect_return = indirect_return(sig, types);
-    if indirect_return {
-        let ret = expand_extern_type(sig.ret.as_ref().unwrap(), types, false);
-        outparam = Some(quote_spanned!(span=> __return: *mut #ret,));
-    }
+    // always indirect return when there's a return value
+    let out_param = sig.ret.as_ref().map(|ret| {
+        let ret = expand_extern_type(ret, types, false);
+        quote_spanned!(span=> __return: *mut #ret,)
+    });
+    let out = match sig.ret {
+        Some(_) => quote_spanned!(span=> __return),
+        None => quote_spanned!(span=> &mut ()),
+    };
+    let indirect_return = sig.ret.is_some();
     if sig.throws {
-        let out = match sig.ret {
-            Some(_) => quote_spanned!(span=> __return),
-            None => quote_spanned!(span=> &mut ()),
-        };
         requires_closure = true;
         requires_unsafe = true;
         expr = quote_spanned!(span=> ::cxx::private::r#try(#out, #expr));
@@ -1143,13 +1143,15 @@ fn expand_rust_function_shim_impl(
         quote!(#local_name)
     };
 
-    expr = quote_spanned!(span=> ::cxx::private::prevent_unwind(__fn, #closure));
-
-    let ret = if sig.throws {
-        quote!(-> ::cxx::private::Result)
+    if sig.throws {
+        // the function itself throws, wire through the exception
+        expr = quote_spanned!(span=> ::cxx::private::try_unwind(__fn, #closure));
     } else {
-        expand_extern_return_type(&sig.ret, types, false)
-    };
+        // always protect against the panic
+        expr = quote_spanned!(span=> ::cxx::private::catch_unwind(__fn, #closure));
+    }
+    // rust functions always potentially throw
+    let ret = quote!(-> ::cxx::private::Result);
 
     let pointer = match invoke {
         None => Some(quote_spanned!(span=> __extern: *const ())),
@@ -1160,7 +1162,7 @@ fn expand_rust_function_shim_impl(
         #attrs
         #[doc(hidden)]
         #[export_name = #link_name]
-        unsafe extern "C" fn #local_name #generics(#(#all_args,)* #outparam #pointer) #ret {
+        unsafe extern "C" fn #local_name #generics(#(#all_args,)* #out_param #pointer) #ret {
             let __fn = ::cxx::private::concat!(::cxx::private::module_path!(), #prevent_unwind_label);
             #wrap_super
             #expr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,9 @@ pub mod private {
     pub use crate::shared_ptr::SharedPtrTarget;
     pub use crate::string::StackString;
     pub use crate::unique_ptr::UniquePtrTarget;
+    pub use crate::unwind::catch_unwind;
     pub use crate::unwind::prevent_unwind;
+    pub use crate::unwind::try_unwind;
     pub use crate::weak_ptr::WeakPtrTarget;
     pub use core::{concat, module_path};
     pub use cxxbridge_macro::type_id;

--- a/src/result.rs
+++ b/src/result.rs
@@ -23,6 +23,16 @@ pub union Result {
     ok: *const u8, // null
 }
 
+impl Result {
+    pub(crate) fn ok() -> Self {
+        Result { ok: ptr::null() }
+    }
+
+    pub(crate) fn error<E: Display>(err: E) -> Self {
+        unsafe { to_c_error(err.to_string()) }
+    }
+}
+
 pub unsafe fn r#try<T, E>(ret: *mut T, result: StdResult<T, E>) -> Result
 where
     E: Display,
@@ -30,9 +40,9 @@ where
     match result {
         Ok(ok) => {
             unsafe { ptr::write(ret, ok) }
-            Result { ok: ptr::null() }
+            Result::ok()
         }
-        Err(err) => unsafe { to_c_error(err.to_string()) },
+        Err(err) => Result::error(err),
     }
 }
 

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -1,6 +1,9 @@
 #![allow(missing_docs)]
 
-use core::mem;
+use alloc::boxed::Box;
+use alloc::format;
+use core::{any::Any, mem};
+use std::panic;
 
 pub fn prevent_unwind<F, R>(label: &'static str, foreign_call: F) -> R
 where
@@ -36,4 +39,33 @@ impl Drop for Guard {
     fn drop(&mut self) {
         panic!("panic in ffi function {}, aborting.", self.label);
     }
+}
+
+/// Run the void `foreign_call`, intercepting panics and converting them to errors.
+pub fn catch_unwind<F>(label: &'static str, foreign_call: F) -> ::cxx::private::Result
+where
+    F: FnOnce(),
+{
+    match panic::catch_unwind(panic::AssertUnwindSafe(foreign_call)) {
+        Ok(()) => ::cxx::private::Result::ok(),
+        Err(err) => panic_result(label, &err),
+    }
+}
+
+/// Run the error-returning `foreign_call`, intercepting panics and converting them to errors.
+pub fn try_unwind<F>(label: &'static str, foreign_call: F) -> ::cxx::private::Result
+where
+    F: FnOnce() -> ::cxx::private::Result,
+{
+    match panic::catch_unwind(panic::AssertUnwindSafe(foreign_call)) {
+        Ok(r) => r,
+        Err(err) => panic_result(label, &err),
+    }
+}
+
+fn panic_result(label: &'static str, err: &Box<dyn Any + Send>) -> ::cxx::private::Result {
+    if let Some(err) = err.downcast_ref::<alloc::string::String>() {
+        return ::cxx::private::Result::error(format!("panic in {label}: {err}"));
+    }
+    ::cxx::private::Result::error(format!("panic in {label}"))
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -316,6 +316,8 @@ pub mod ffi {
 
         #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
+
+        fn r_panic(s: &str);
     }
 
     struct Dag0 {
@@ -649,4 +651,8 @@ fn r_try_return_mutsliceu8(slice: &mut [u8]) -> Result<&mut [u8], Error> {
 
 fn r_aliased_function(x: i32) -> String {
     x.to_string()
+}
+
+fn r_panic(s: &str) {
+    panic!("{s}");
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -904,6 +904,13 @@ extern "C" const char *cxx_run_test() noexcept {
   (void)rust::Vec<size_t>();
   (void)rust::Vec<rust::isize>();
 
+  try {
+    r_panic("foobar");
+    ASSERT(false);
+  } catch (const rust::Error &e) {
+    ASSERT(std::strcmp(e.what(), "panic in cxx_test_suite::ffi::r_panic: foobar") == 0);
+  }
+
   cxx_test_suite_set_correct();
   return nullptr;
 }


### PR DESCRIPTION
_This is the first change in a series to replace abort on panic with exceptions._

This change replaces the usage of aborting `prevent_unwind` with new error-generating `catch_unwind` and `try_unwind` in ffi *rust functions* only (see the note below).

It largerly uses existing setup for returning exceptions in case of `Result` return type by forecibly enabling it.

Since handling exceptions in cxx requires passing return values as pointer arguments (see example), this transformation requires specificatin of return references lifetime (eforced by #3)

There are plenty of remaining usages of `prevent_unwind` but they are all (mostly?) concerned generating various
c++ operators (that we don't really use). I intend to fix them in follow ups.

Internal PR 8720

## Example shim 

For `fn r_return_identity(_: usize) -> usize;`

### Before

```rust
#[export_name = "tests$cxxbridge1$r_return_identity"]
unsafe extern "C" fn __r_return_identity(arg0: usize) -> usize {
    let __fn = "cxx_test_suite::ffi::r_return_identity";
    fn __r_return_identity(arg0: usize) -> usize {
        super::r_return_identity(arg0)
    }
    ::cxx::private::prevent_unwind(__fn, move || __r_return_identity(arg0))
}
```

```c++
::std::size_t r_return_identity(::std::size_t arg0) noexcept {
  return tests$cxxbridge1$r_return_identity(arg0);
}
```


### After

```rust
#[export_name = "tests$cxxbridge1$r_return_identity"]
unsafe extern "C" fn __r_return_identity(
    arg0: usize,
    __return: *mut usize,
) -> ::cxx::private::Result {
    let __fn = "cxx_test_suite::ffi::r_return_identity";
    fn __r_return_identity(arg0: usize) -> usize {
        super::r_return_identity(arg0)
    }
    ::cxx::private::catch_unwind(
        __fn,
        move || unsafe {
            ::cxx::core::ptr::write(__return, __r_return_identity(arg0))
        },
    )
}
```
```c++
::std::size_t r_return_identity(::std::size_t arg0) {
  ::rust::MaybeUninit<::std::size_t> return$;
  ::rust::repr::PtrLen error$ = tests$cxxbridge1$r_return_identity(arg0, &return$.value);
  if (error$.ptr) {
    throw ::rust::impl<::rust::Error>::error(error$);
  }
  return ::std::move(return$.value);
}
```
