### PR TITLE
[workerd-cxx] rust error callback

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -346,21 +346,7 @@ pub fn write(out: &mut OutFile) {
         }
         writeln!(out, "}};");
     }
-
-    if builtin.rust_error {
-        out.next_section();
-        writeln!(out, "template <>");
-        writeln!(out, "class impl<Error> final {{");
-        writeln!(out, "public:");
-        writeln!(out, "  static Error error(repr::PtrLen repr) noexcept {{");
-        writeln!(out, "    Error error;");
-        writeln!(out, "    error.msg = static_cast<char const *>(repr.ptr);");
-        writeln!(out, "    error.len = repr.len;");
-        writeln!(out, "    return error;");
-        writeln!(out, "  }}");
-        writeln!(out, "}};");
-    }
-
+    
     if builtin.destroy {
         out.next_section();
         writeln!(out, "template <typename T>");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1130,7 +1130,10 @@ fn write_rust_function_shim_impl(
     writeln!(out, ";");
     out.builtin.rust_error = true;
     writeln!(out, "  if (error$.ptr) {{");
-    writeln!(out, "    throw ::rust::impl<::rust::Error>::error(error$);");
+    writeln!(
+        out,
+        "    ::rust::throw_rust_error(static_cast<char const *>(error$.ptr), error$.len);"
+    );
     writeln!(out, "  }}");
 
     if indirect_return {

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -42,6 +42,11 @@ template <typename T>
 class impl;
 }
 
+// Global handler for rust errors.
+// msg is 0-terminated, size counts the 0.
+// msg was new char[] allocated, ownership is transferred to throw_rust_error.
+extern void (*throw_rust_error)(const char *msg, size_t size); // NOLINT
+
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
 // https://cxx.rs/binding/string.html
@@ -435,6 +440,9 @@ public:
   Error &operator=(Error &&) & noexcept;
 
   const char *what() const noexcept override;
+
+  // Default handler for throw_rust_error: create new Error instance and throw it.
+  static void error(const char *, size_t);
 
 private:
   Error() noexcept = default;

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -86,6 +86,8 @@ void panic [[noreturn]] (const char *msg) {
 
 template void panic<std::out_of_range> [[noreturn]] (const char *msg);
 
+void (*throw_rust_error)(const char*, size_t) = Error::error; // NOLINT
+
 template <typename T>
 static bool is_aligned(const void *ptr) noexcept {
   auto iptr = reinterpret_cast<std::uintptr_t>(ptr);
@@ -511,6 +513,13 @@ Error &Error::operator=(Error &&other) & noexcept {
 }
 
 const char *Error::what() const noexcept { return this->msg; }
+
+void Error::error(const char *ptr, std::size_t len) {
+  Error error;
+  error.msg = ptr;
+  error.len = len;
+  throw error;
+}
 
 namespace {
 template <typename T>


### PR DESCRIPTION
Introduce `::rust::throw_rust_error` callback of `void (const char*, size_t)` type. The callback is used every time rust functions returns `Result::Err` (or triggers panic with #2).

We will use the callback in workerd to integrate with kj::Exception