### PR TITLE
kj-rs/convert.h for kj-rust object conversion

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -22,7 +22,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
@@ -76,7 +77,6 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
@@ -97,8 +97,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -143,15 +143,15 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
     "//:capnp_cpp.bzl%capnp_cpp": {
       "general": {
-        "bzlTransitiveDigest": "tqp8PD7PlIMw+hub/Gbb35YemjvGP2zQXuqcFPcY4r8=",
+        "bzlTransitiveDigest": "cN2zu1TVplePM9IOMZVwbR9OMrmIBSc+1wstMXqSP84=",
         "usagesDigest": "NcY49Lqyy8czgriyQfqodZtzPlf0EyttkWX8b7osJtY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -160,10 +160,10 @@
           "capnp-cpp": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/capnproto/capnproto/tarball/fd3001e9ae9c8efaa007518901711ead5584167a",
-              "strip_prefix": "capnproto-capnproto-fd3001e/c++",
+              "url": "https://github.com/capnproto/capnproto/tarball/5b8cae919e37898d47290e5edd777e1aa6be802a",
+              "strip_prefix": "capnproto-capnproto-5b8cae9/c++",
               "type": "tgz",
-              "sha256": "ce4d082c20f2df051d718a3a72fc6029e84c589c87bc93b8cfeb79522577e822"
+              "sha256": "bb508a1762ca4af7b01162c38a2153e4b77595f612aeb27d2b560cc16302bf14"
             }
           }
         },
@@ -209,7 +209,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/capnp_cpp.bzl
+++ b/capnp_cpp.bzl
@@ -1,11 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 
-URL = "https://github.com/capnproto/capnproto/tarball/fd3001e9ae9c8efaa007518901711ead5584167a"
-STRIP_PREFIX = "capnproto-capnproto-fd3001e/c++"
-SHA256 = "ce4d082c20f2df051d718a3a72fc6029e84c589c87bc93b8cfeb79522577e822"
+URL = "https://github.com/capnproto/capnproto/tarball/5b8cae919e37898d47290e5edd777e1aa6be802a"
+STRIP_PREFIX = "capnproto-capnproto-5b8cae9/c++"
+SHA256 = "bb508a1762ca4af7b01162c38a2153e4b77595f612aeb27d2b560cc16302bf14"
 TYPE = "tgz"
-COMMIT = "fd3001e9ae9c8efaa007518901711ead5584167a"
+COMMIT = "5b8cae919e37898d47290e5edd777e1aa6be802a"
 
 def _capnp_cpp(ctx):
     http_archive(

--- a/kj-rs/convert.h
+++ b/kj-rs/convert.h
@@ -1,0 +1,237 @@
+#pragma once
+
+// kj-rs/convert.h - Rust/C++ Interoperability Utilities for KJ
+//
+// This header provides seamless integration between Rust types and KJ (Cap'n Proto's C++ library)
+// types, enabling efficient and safe data exchange across the language boundary.
+//
+// ============================================================================
+// USAGE OVERVIEW
+// ============================================================================
+//
+// Converting C++ kj arrays, strings, etc to Rust:
+// - kjObject.as<Rust>() - creates zero-copy read-only Rust view
+// - kjObject.as<RustMutable>() - creates zero-copy mutable Rust view
+// - kjObject.as<RustCopy>() - creates owned Rust copy
+//
+// Converting Rust to C++ kj objects:
+// - from<Rust>(rustObject) - creates zero-copy C++ view
+// - from<RustCopy>(rustObject) - creates owned C++ copy
+// - kj::str(rustString) - automatic conversion (via KJ_STRINGIFY)
+// - kj::hashCode(rustString) - automatic hash computation (via KJ_HASHCODE)
+//
+// ============================================================================
+// CONVERSION FUNCTIONS
+// ============================================================================
+//
+// Zero-copy conversions from Rust to C++:
+// - from<Rust>(rust::Vec<T>) -> kj::ArrayPtr<const T>
+// - from<Rust>(rust::Slice<T>) -> kj::ArrayPtr<T>
+// - from<Rust>(rust::String) -> kj::ArrayPtr<const char>
+// - from<Rust>(rust::str) -> kj::ArrayPtr<const char>
+//
+// Owned conversions from Rust to C++:
+// - from<RustCopy>(rust::Slice<rust::str>) -> kj::Array<kj::String>
+// - from<RustCopy>(rust::Vec<rust::String>) -> kj::Array<kj::String>
+//
+// Zero-copy conversions from C++ to Rust (read-only):
+// - kjArray.as<Rust>() -> rust::Slice<const T>
+// - kjString.as<Rust>() -> rust::String
+// - kjStringPtr.as<Rust>() -> rust::str
+// - kjConstString.as<Rust>() -> rust::str
+//
+// Zero-copy conversions from C++ to Rust (mutable):
+// - kjArray.as<RustMutable>() -> rust::Slice<T>
+// - kjArrayPtr.as<RustMutable>() -> rust::Slice<T>
+//
+// Owned conversions from C++ to Rust (copying):
+// - kjStringPtr.as<RustCopy>() -> rust::String
+// - kjConstString.as<RustCopy>() -> rust::String
+// - kjArrayPtr.as<RustCopy>() -> rust::Vec<T>
+//
+// Automatic conversions (via ADL):
+// - kj::str(rust::String) - uses KJ_STRINGIFY for seamless string conversion
+// - kj::hashCode(rust::String) - uses KJ_HASHCODE for hash computation
+//
+// ============================================================================
+// EXAMPLES
+// ============================================================================
+//
+// Basic usage patterns:
+//
+// // Convert Rust to C++:
+// kj::ArrayPtr<const int> cppView = from<Rust>(rustVec);
+//
+// // Convert C++ to Rust (read-only):
+// rust::Slice<const int> rustView = cppArray.as<Rust>();
+//
+// // Convert C++ to Rust (mutable):
+// rust::Slice<int> rustMutableView = cppArray.as<RustMutable>();
+//
+// // Convert C++ to Rust (copying):
+// rust::String rustOwnedStr = cppStr.as<RustCopy>();
+//
+// // Automatic string conversion:
+// kj::String cppStr = kj::str(rustStr);  // via KJ_STRINGIFY
+//
+
+#include <rust/cxx.h>
+
+#include <kj/common.h>
+#include <kj/hash.h>
+#include <kj/string.h>
+
+namespace rust {
+
+// Automatic KJ Integration Functions - enable ADL for kj::str() and kj::hashCode()
+
+/// Converts rust::String to kj::ArrayPtr - called by kj::str(rustString)
+inline auto KJ_STRINGIFY(const ::rust::String& str) {
+  // HACK: rust::String is not null-terminated, so we use kj::ArrayPtr instead
+  // which usually acts like kj::StringPtr but does not rely on null
+  // termination.
+  return kj::ArrayPtr<const char>(str.data(), str.size());
+}
+
+/// Converts rust::str to kj::ArrayPtr - called by kj::str(rustStr)
+inline auto KJ_STRINGIFY(const ::rust::str& str) {
+  // HACK: rust::str is not null-terminated, so we use kj::ArrayPtr instead
+  // which usually acts like kj::StringPtr but does not rely on null
+  // termination.
+  return kj::ArrayPtr<const char>(str.data(), str.size());
+}
+
+/// Hash code for rust::String - called by kj::hashCode(rustString)
+inline auto KJ_HASHCODE(const ::rust::String& str) {
+  return kj::hashCode(kj::toCharSequence(str));
+}
+
+/// Hash code for rust::str - called by kj::hashCode(rustStr)
+inline auto KJ_HASHCODE(const ::rust::str& str) {
+  return kj::hashCode(kj::toCharSequence(str));
+}
+
+}  // namespace rust
+
+namespace kj_rs {
+
+// KJ to Rust conversion utilities with different ownership semantics
+
+/// Template function for nicer syntax: from<Rust>(rustObject) instead of fromRust(rustObject)
+template <typename T, typename U>
+inline auto from(U&& rustObject) {
+  return T::into(std::forward<U>(rustObject));
+}
+
+/// Zero-copy read-only Rust views: kjObject.as<Rust>() and from<Rust>(kjObject)
+struct Rust {
+  /// kjArrayPtr.as<Rust>() - via Rust::from(&kjArrayPtr)
+  template <typename T>
+  static ::rust::Slice<const T> from(const kj::ArrayPtr<T>* arr) {
+    return ::rust::Slice<const T>(arr->begin(), arr->size());
+  }
+
+  /// kjArray.as<Rust>() - via Rust::from(&kjArray)
+  template <typename T>
+  static ::rust::Slice<const T> from(const kj::Array<T>* arr) {
+    return ::rust::Slice<const T>(arr->begin(), arr->size());
+  }
+
+  /// kjString.as<Rust>() - via Rust::from(&kjString)
+  static ::rust::String from(const kj::String* str) {
+    return ::rust::String(str->begin(), str->size());
+  }
+
+  /// kjStringPtr.as<Rust>() - via Rust::from(&kjStringPtr)
+  static ::rust::Str from(const kj::StringPtr* str) {
+    return ::rust::Str(str->begin(), str->size());
+  }
+
+  /// kjConstString.as<Rust>() - via Rust::from(&kjConstString)
+  static ::rust::Str from(const kj::ConstString* str) {
+    return ::rust::Str(str->begin(), str->size());
+  }
+
+  // into() methods for from<Rust>(rustObject) - converting Rust to KJ
+
+  /// from<Rust>(rustVec) - Zero-copy read-only view
+  template <typename T>
+  static kj::ArrayPtr<const T> into(const ::rust::Vec<T>& vec) {
+    return kj::ArrayPtr<const T>(vec.data(), vec.size());
+  }
+
+  /// from<Rust>(rustSlice) - Zero-copy slice view
+  template <typename T>
+  static kj::ArrayPtr<T> into(const ::rust::Slice<T>& slice) {
+    return kj::ArrayPtr<T>(slice.data(), slice.size());
+  }
+
+  /// from<Rust>(rustString) - Zero-copy string chars (not null-terminated)
+  static kj::ArrayPtr<const char> into(const ::rust::String& str) {
+    return kj::ArrayPtr<const char>(str.data(), str.size());
+  }
+
+  /// from<Rust>(rustStr) - Zero-copy string slice chars (not null-terminated)
+  static kj::ArrayPtr<const char> into(const ::rust::Str& str) {
+    return kj::ArrayPtr<const char>(str.data(), str.size());
+  }
+};
+
+/// Owned Rust copies: kjObject.as<RustCopy>() and from<RustCopy>(kjObject)
+struct RustCopy {
+  /// kjStringPtr.as<RustCopy>() - via RustCopy::from(&kjStringPtr)
+  static ::rust::String from(const kj::StringPtr* str) {
+    return ::rust::String(str->begin(), str->size());
+  }
+
+  /// kjConstString.as<RustCopy>() - via RustCopy::from(&kjConstString)
+  static ::rust::String from(const kj::ConstString* str) {
+    return ::rust::String(str->begin(), str->size());
+  }
+
+  /// kjArrayPtr.as<RustCopy>() - via RustCopy::from(&kjArrayPtr)
+  template <typename T>
+  static ::rust::Vec<T> from(kj::ArrayPtr<const T>* arr) {
+    ::rust::Vec<T> result;
+    result.reserve(arr->size());
+    for (auto& t: *arr) {
+      result.push_back(t);
+    }
+    return result;
+  }
+
+  /// from<RustCopy>(rustSliceOfStrs) - Copy slice of strs to null-terminated KJ strings
+  static kj::Array<kj::String> into(::rust::Slice<::rust::str> slice) {
+    auto res = kj::heapArrayBuilder<kj::String>(slice.size());
+    for (auto& entry: slice) {
+      res.add(kj::str(entry));
+    }
+    return res.finish();
+  }
+
+  /// from<RustCopy>(rustVecOfStrings) - Copy string vector to null-terminated KJ strings
+  static kj::Array<kj::String> into(const ::rust::Vec<::rust::String>& vec) {
+    auto res = kj::heapArrayBuilder<kj::String>(vec.size());
+    for (auto& entry: vec) {
+      res.add(kj::str(entry));
+    }
+    return res.finish();
+  }
+};
+
+/// Mutable Rust views: kjObject.as<RustMutable>() and from<RustMutable>(kjObject)
+struct RustMutable {
+  /// kjArrayPtr.as<RustMutable>() - via RustMutable::from(&kjArrayPtr)
+  template <typename T>
+  static ::rust::Slice<T> from(kj::ArrayPtr<T>* arr) {
+    return ::rust::Slice<T>(arr->begin(), arr->size());
+  }
+
+  /// kjArray.as<RustMutable>() - via RustMutable::from(&kjArray)
+  template <typename T>
+  static ::rust::Slice<T> from(kj::Array<T>* arr) {
+    return ::rust::Slice<T>(arr->begin(), arr->size());
+  }
+};
+
+}  // namespace kj_rs

--- a/kj-rs/kj-rs.h
+++ b/kj-rs/kj-rs.h
@@ -1,4 +1,8 @@
 #pragma once
 
+// KJ-C++ conversion utilities
+#include "kj-rs/convert.h"
+// Rust futures support
 #include "kj-rs/future.h"
+// KJ promises support
 #include "kj-rs/promise.h"

--- a/kj-rs/tests/BUILD.bazel
+++ b/kj-rs/tests/BUILD.bazel
@@ -85,3 +85,20 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "kj-test",
+    size = "small",
+    srcs = [
+        "convert.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    deps = [
+        "//kj-rs",
+        "//third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/kj-rs/tests/convert.c++
+++ b/kj-rs/tests/convert.c++
@@ -1,0 +1,270 @@
+#include "kj-rs/convert.h"
+
+#include <rust/cxx.h>
+
+#include <kj/array.h>
+#include <kj/string.h>
+#include <kj/test.h>
+
+// Test kj-rs integration utilities for Rust/C++ interoperability
+
+namespace kj_rs {
+
+KJ_TEST("rust::String with kj::str") {
+  // Create a rust::String
+  ::rust::String rustStr("Hello, World!");
+
+  // Test that kj::str() automatically uses our KJ_STRINGIFY function
+  auto kjStr = kj::str(rustStr);
+
+  KJ_EXPECT(kjStr == "Hello, World!");
+  KJ_EXPECT(kjStr.size() == rustStr.size());
+}
+
+KJ_TEST("rust::str with kj::str") {
+  // Create a rust::str
+  ::rust::str rustStr("Rust string slice");
+
+  // Test that kj::str() automatically uses our KJ_STRINGIFY function
+  auto kjStr = kj::str(rustStr);
+
+  KJ_EXPECT(kjStr == "Rust string slice");
+  KJ_EXPECT(kjStr.size() == rustStr.size());
+}
+
+KJ_TEST("rust::String with kj::hashCode") {
+  ::rust::String rustStr("hash test");
+  kj::StringPtr kjStr = "hash test";
+
+  // Test that kj::hashCode() automatically uses our KJ_HASHCODE function
+  auto rustHash = kj::hashCode(rustStr);
+  auto kjHash = kj::hashCode(kjStr);
+
+  KJ_EXPECT(rustHash == kjHash);
+}
+
+KJ_TEST("rust::str with kj::hashCode") {
+  ::rust::str rustStr("hash test slice");
+  kj::StringPtr kjStr = "hash test slice";
+
+  // Test that kj::hashCode() automatically uses our KJ_HASHCODE function
+  auto rustHash = kj::hashCode(rustStr);
+  auto kjHash = kj::hashCode(kjStr);
+
+  KJ_EXPECT(rustHash == kjHash);
+}
+
+KJ_TEST("from<Rust> Vec conversion") {
+  // Create a rust::Vec with some data
+  ::rust::Vec<int> rustVec;
+  rustVec.push_back(1);
+  rustVec.push_back(2);
+  rustVec.push_back(3);
+
+  // Convert to kj::ArrayPtr
+  auto arrayPtr = from<Rust>(rustVec);
+
+  KJ_EXPECT(arrayPtr.size() == 3);
+  KJ_EXPECT(arrayPtr[0] == 1);
+  KJ_EXPECT(arrayPtr[1] == 2);
+  KJ_EXPECT(arrayPtr[2] == 3);
+}
+
+KJ_TEST("from<Rust> Slice conversion") {
+  // Create some data and a rust::Slice
+  int data[] = {10, 20, 30, 40};
+  ::rust::Slice<int> rustSlice(data, 4);
+
+  // Convert to kj::ArrayPtr
+  auto arrayPtr = from<Rust>(rustSlice);
+
+  KJ_EXPECT(arrayPtr.size() == 4);
+  KJ_EXPECT(arrayPtr[0] == 10);
+  KJ_EXPECT(arrayPtr[1] == 20);
+  KJ_EXPECT(arrayPtr[2] == 30);
+  KJ_EXPECT(arrayPtr[3] == 40);
+}
+
+KJ_TEST("from<Rust> String conversion") {
+  ::rust::String rustStr("Convert me!");
+
+  auto arrayPtr = from<Rust>(rustStr);
+  auto kjStr = kj::str(arrayPtr);
+
+  KJ_EXPECT(kjStr == "Convert me!");
+  KJ_EXPECT(arrayPtr.size() == rustStr.size());
+}
+
+KJ_TEST("from<Rust> Str conversion") {
+  ::rust::Str rustStr("String slice conversion");
+
+  auto arrayPtr = from<Rust>(rustStr);
+  auto kjStr = kj::str(arrayPtr);
+
+  KJ_EXPECT(kjStr == "String slice conversion");
+  KJ_EXPECT(arrayPtr.size() == rustStr.size());
+}
+
+KJ_TEST("from<RustCopy> Slice<str> conversion") {
+  ::rust::str strings[] = {"first", "second", "third"};
+  ::rust::Slice<::rust::str> rustSlice(strings, 3);
+
+  auto kjArray = from<RustCopy>(rustSlice);
+
+  KJ_EXPECT(kjArray.size() == 3);
+  KJ_EXPECT(kjArray[0] == "first");
+  KJ_EXPECT(kjArray[1] == "second");
+  KJ_EXPECT(kjArray[2] == "third");
+}
+
+KJ_TEST("from<RustCopy> Vec<String> conversion") {
+  ::rust::Vec<::rust::String> rustVec;
+  rustVec.emplace_back("first");
+  rustVec.emplace_back("second");
+  rustVec.emplace_back("third");
+
+  auto kjArray = from<RustCopy>(rustVec);
+
+  KJ_EXPECT(kjArray.size() == 3);
+  KJ_EXPECT(kjArray[0] == "first");
+  KJ_EXPECT(kjArray[1] == "second");
+  KJ_EXPECT(kjArray[2] == "third");
+}
+
+KJ_TEST("Rust string - ArrayPtr to Slice conversion") {
+  kj::Array<int> kjArray = kj::heapArray<int>({1, 2, 3, 4, 5});
+  kj::ArrayPtr<int> arrayPtr = kjArray.asPtr();
+
+  auto rustSlice = arrayPtr.as<Rust>();
+
+  KJ_EXPECT(rustSlice.size() == 5);
+  KJ_EXPECT(rustSlice[0] == 1);
+  KJ_EXPECT(rustSlice[4] == 5);
+}
+
+KJ_TEST("Rust string - Array to Slice conversion") {
+  kj::Array<int> kjArray = kj::heapArray<int>({10, 20, 30});
+
+  auto rustSlice = kjArray.as<Rust>();
+
+  KJ_EXPECT(rustSlice.size() == 3);
+  KJ_EXPECT(rustSlice[0] == 10);
+  KJ_EXPECT(rustSlice[1] == 20);
+  KJ_EXPECT(rustSlice[2] == 30);
+}
+
+KJ_TEST("Rust string - String conversion") {
+  kj::String kjStr = kj::str("KJ to Rust string");
+
+  auto rustString = kjStr.as<Rust>();
+
+  KJ_EXPECT(rustString.size() == kjStr.size());
+  // Compare content by converting back
+  auto convertedBack = kj::str(rustString);
+  KJ_EXPECT(convertedBack == kjStr);
+}
+
+KJ_TEST("Rust string - StringPtr conversion") {
+  kj::StringPtr kjStrPtr = "StringPtr to Rust";
+
+  auto rustStr = kjStrPtr.as<Rust>();
+
+  KJ_EXPECT(rustStr.size() == kjStrPtr.size());
+  auto convertedBack = kj::str(rustStr);
+  KJ_EXPECT(convertedBack == kjStrPtr);
+}
+
+KJ_TEST("RustCopy struct - StringPtr conversion") {
+  kj::StringPtr kjStrPtr = "Copy this string";
+
+  auto rustString = kjStrPtr.as<RustCopy>();
+
+  KJ_EXPECT(rustString.size() == kjStrPtr.size());
+  auto convertedBack = kj::str(rustString);
+  KJ_EXPECT(convertedBack == kjStrPtr);
+}
+
+KJ_TEST("RustCopy struct - ArrayPtr conversion") {
+  kj::Array<double> kjArray = kj::heapArray<double>({1.1, 2.2, 3.3});
+  kj::ArrayPtr<const double> arrayPtr = kjArray.asPtr();
+
+  auto rustVec = arrayPtr.as<RustCopy>();
+
+  KJ_EXPECT(rustVec.size() == 3);
+  KJ_EXPECT(rustVec[0] == 1.1);
+  KJ_EXPECT(rustVec[1] == 2.2);
+  KJ_EXPECT(rustVec[2] == 3.3);
+}
+
+KJ_TEST("RustMutable struct - ArrayPtr conversion") {
+  kj::Array<int> kjArray = kj::heapArray<int>({100, 200, 300});
+  kj::ArrayPtr<int> arrayPtr = kjArray.asPtr();
+
+  auto rustSlice = arrayPtr.as<RustMutable>();
+
+  KJ_EXPECT(rustSlice.size() == 3);
+  KJ_EXPECT(rustSlice[0] == 100);
+  KJ_EXPECT(rustSlice[1] == 200);
+  KJ_EXPECT(rustSlice[2] == 300);
+
+  // Test that we can modify through the mutable slice
+  rustSlice[0] = 999;
+  KJ_EXPECT(kjArray[0] == 999);  // Should be modified in original array
+}
+
+KJ_TEST("RustMutable struct - Array conversion") {
+  kj::Array<char> kjArray = kj::heapArray<char>({'a', 'b', 'c'});
+
+  auto rustSlice = kjArray.as<RustMutable>();
+
+  KJ_EXPECT(rustSlice.size() == 3);
+  KJ_EXPECT(rustSlice[0] == 'a');
+  KJ_EXPECT(rustSlice[1] == 'b');
+  KJ_EXPECT(rustSlice[2] == 'c');
+
+  // Test mutability
+  rustSlice[1] = 'X';
+  KJ_EXPECT(kjArray[1] == 'X');
+}
+
+KJ_TEST("kj::ConstString as<Rust> conversion") {
+  kj::ConstString kjConstStr = "ConstString test"_kjc;
+
+  auto rustStr = kjConstStr.as<Rust>();
+
+  KJ_EXPECT(rustStr.size() == kjConstStr.size());
+  auto convertedBack = kj::str(rustStr);
+  KJ_EXPECT(convertedBack == kjConstStr);
+}
+
+KJ_TEST("kj::ConstString as<RustCopy> conversion") {
+  kj::ConstString kjConstStr = "Copy ConstString test"_kjc;
+
+  auto rustString = kjConstStr.as<RustCopy>();
+
+  KJ_EXPECT(rustString.size() == kjConstStr.size());
+  auto convertedBack = kj::str(rustString);
+  KJ_EXPECT(convertedBack == kjConstStr);
+}
+
+KJ_TEST("kj::LiteralStringConst as<Rust> conversion") {
+  auto kjLiteralStr = "LiteralStringConst test"_kjc;
+
+  auto rustStr = kjLiteralStr.as<Rust>();
+
+  KJ_EXPECT(rustStr.size() == kjLiteralStr.size());
+  auto convertedBack = kj::str(rustStr);
+  KJ_EXPECT(convertedBack == kjLiteralStr);
+}
+
+KJ_TEST("kj::LiteralStringConst as<RustCopy> conversion") {
+  auto kjLiteralStr = "Copy LiteralStringConst test"_kjc;
+
+  auto rustString = kjLiteralStr.as<RustCopy>();
+
+  KJ_EXPECT(rustString.size() == kjLiteralStr.size());
+  auto convertedBack = kj::str(rustString);
+  KJ_EXPECT(convertedBack == kjLiteralStr);
+}
+
+}  // namespace kj_rs


### PR DESCRIPTION
Improved iteration of https://github.com/cloudflare/workerd/blob/main/src/rust/cxx-integration/cxx-bridge.h

Main difference: introduction of `from<Rust>` and `from<RustCopy>`