### PR TITLE
[workerd-cxx] remove + Send from futures

### DIFF
--- a/kj-rs/awaiter.rs
+++ b/kj-rs/awaiter.rs
@@ -6,16 +6,6 @@ use crate::ffi::{GuardedRustPromiseAwaiter, GuardedRustPromiseAwaiterRepr};
 use crate::waker::try_into_kj_waker_ptr;
 
 // =======================================================================================
-// GuardedRustPromiseAwaiter
-
-// Safety: KJ Promises are not associated with threads, but with event loops at construction time.
-// Therefore, they can be polled from any thread, as long as that thread has the correct event loop
-// active at the time of the call to `poll()`. If the correct event loop is not active,
-// GuardedRustPromiseAwaiter's API will panic. (The Guarded- prefix refers to the C++ class template
-// ExecutorGuarded, which enforces the correct event loop requirement.)
-unsafe impl Send for GuardedRustPromiseAwaiter {}
-
-// =======================================================================================
 // Await syntax for OwnPromiseNode
 
 use crate::OwnPromiseNode;

--- a/kj-rs/future.rs
+++ b/kj-rs/future.rs
@@ -38,9 +38,9 @@ pub(crate) mod repr {
 
     type DropCallback = unsafe extern "C" fn(fut: *mut c_void);
 
-    type FuturePtr<'a, T> = *mut (dyn Future<Output = Result<T, String>> + Send + 'a);
+    type FuturePtr<'a, T> = *mut (dyn Future<Output = Result<T, String>> + 'a);
 
-    /// Represents a `dyn Future<Output = Result<T, String>>` + Send.
+    /// Represents a `dyn Future<Output = Result<T, String>>`.
     #[repr(C)]
     pub struct RustFuture<'a, T> {
         pub fut: FuturePtr<'a, T>,
@@ -48,9 +48,9 @@ pub(crate) mod repr {
         pub drop: DropCallback,
     }
 
-    type InfallibleFuturePtr<'a, T> = *mut (dyn Future<Output = T> + Send + 'a);
+    type InfallibleFuturePtr<'a, T> = *mut (dyn Future<Output = T> + 'a);
 
-    /// Represents a `dyn Future<Output = T> + Send` where T is not a Result.
+    /// Represents a `dyn Future<Output = T>` where T is not a Result.
     #[repr(C)]
     pub struct RustInfallibleFuture<'a, T> {
         pub fut: InfallibleFuturePtr<'a, T>,
@@ -127,7 +127,7 @@ pub(crate) mod repr {
 
     #[must_use]
     pub fn future<'a, T: Unpin>(
-        fut: Pin<Box<dyn Future<Output = Result<T, String>> + Send + 'a>>,
+        fut: Pin<Box<dyn Future<Output = Result<T, String>> + 'a>>,
     ) -> RustFuture<'a, T> {
         let fut = Box::into_raw(unsafe { Pin::into_inner_unchecked(fut) });
         let poll = RustFuture::<T>::poll;
@@ -137,7 +137,7 @@ pub(crate) mod repr {
 
     #[must_use]
     pub fn infallible_future<'a, T: Unpin>(
-        fut: Pin<Box<dyn Future<Output = T> + Send + 'a>>,
+        fut: Pin<Box<dyn Future<Output = T> + 'a>>,
     ) -> RustInfallibleFuture<'a, T> {
         let fut = Box::into_raw(unsafe { Pin::into_inner_unchecked(fut) });
         let poll = RustInfallibleFuture::<T>::poll;

--- a/kj-rs/promise.rs
+++ b/kj-rs/promise.rs
@@ -19,15 +19,6 @@ type CxxResult<T> = std::result::Result<T, cxx::Exception>;
 #[repr(transparent)]
 pub struct OwnPromiseNode(*mut c_void /* kj::_::PromiseNode* */);
 
-// Safety: KJ Promises are not associated with threads, but with event loops at construction time.
-// Therefore, they can be polled from any thread, as long as that thread has the correct event loop
-// active at the time of the call to `poll()`. If the correct event loop is not active, the
-// OwnPromiseNode's API will typically panic, undefined behavior could be possible. However, Rust
-// doesn't have direct access to OwnPromiseNode's API. Instead, it can only use the Promise by
-// having GuardedRustPromiseAwaiter consume it, and GuardedRustPromiseAwaiter implements the
-// correct-executor guarantee.
-unsafe impl Send for OwnPromiseNode {}
-
 // Note: drop is not the only way for OwnPromiseNode to be destroyed.
 // It is forgotten using `MaybeUninit` and its ownership passed over to c++ in `unwrap`.
 impl Drop for OwnPromiseNode {

--- a/kj-rs/tests/test_futures.rs
+++ b/kj-rs/tests/test_futures.rs
@@ -150,8 +150,8 @@ pub async fn new_layered_ready_future_void() -> Result<()> {
 
 // From example at https://doc.rust-lang.org/std/future/fn.poll_fn.html#capturing-a-pinned-state
 async fn naive_select<T>(
-    a: impl Future<Output = T> + Send,
-    b: impl Future<Output = T> + Send,
+    a: impl Future<Output = T>,
+    b: impl Future<Output = T>,
 ) -> T {
     let (mut a, mut b) = (pin!(a), pin!(b));
     future::poll_fn(move |cx| {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1268,9 +1268,9 @@ fn expand_rust_function_shim_super(
         };
 
         if fut.throws_tokens.is_some() {
-            quote!(-> std::pin::Pin<Box<dyn ::std::future::Future<Output = ::std::result::Result<#output, String>> + Send #lifetimes>>)
+            quote!(-> std::pin::Pin<Box<dyn ::std::future::Future<Output = ::std::result::Result<#output, String>> #lifetimes>>)
         } else {
-            quote!(-> std::pin::Pin<Box<dyn ::std::future::Future<Output = #output> + Send #lifetimes>>)
+            quote!(-> std::pin::Pin<Box<dyn ::std::future::Future<Output = #output> #lifetimes>>)
         }
     } else {
         expand_return_type(&sig.ret)


### PR DESCRIPTION
We don't want c++ promises to be shared between different threads.