### PR TITLE
[nfc] cleanup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,10 @@ build:windows --copt='/Zc:dllexportInlines-' --host_copt='/Zc:dllexportInlines-'
 
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
-build:clippy  --@rules_rust//:clippy_flags=-Dclippy::all,-Dclippy::pedantic
+build:clippy --@rules_rust//:clippy_flags=-Dclippy::all,-Dclippy::pedantic,-Dwarnings
+build:clippy --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:clippy --output_groups=+rustfmt_checks
+build:clippy --@rules_rust//:extra_rustc_flag=-Dwarnings
 
 ## Sanitizers
 

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -51,7 +51,6 @@
     clippy::cast_sign_loss,
     clippy::default_trait_access,
     clippy::doc_markdown,
-    clippy::elidable_lifetime_names,
     clippy::enum_glob_use,
     clippy::explicit_auto_deref,
     clippy::inherent_to_string,

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1030,11 +1030,15 @@ fn write_rust_function_shim_impl(
         return;
     }
     writeln!(out, " {{");
-    sig.args.iter()
-        .filter(|arg| {
-            matches!(arg.ty, Type::Own(_))
-        }).for_each(|arg_own| {
-            writeln!(out, "  KJ_ASSERT({}.get() != nullptr, \"Cannot pass a null Own to Rust\");", arg_own.name.cxx);
+    sig.args
+        .iter()
+        .filter(|arg| matches!(arg.ty, Type::Own(_)))
+        .for_each(|arg_own| {
+            writeln!(
+                out,
+                "  KJ_ASSERT({}.get() != nullptr, \"Cannot pass a null Own to Rust\");",
+                arg_own.name.cxx
+            );
         });
     for arg in &sig.args {
         if arg.ty != RustString && out.types.needs_indirect_abi(&arg.ty) {
@@ -1634,7 +1638,7 @@ fn write_kj_own(out: &mut OutFile, key: NamedImplKey) {
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
-    
+
     out.include.utility = true;
     out.include.kj_rs = true;
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1637,7 +1637,6 @@ fn write_kj_own(out: &mut OutFile, key: NamedImplKey) {
     let ident = key.rust;
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
-    let instance = resolve.name.to_symbol();
 
     out.include.utility = true;
     out.include.kj_rs = true;

--- a/kj-rs/awaiter.rs
+++ b/kj-rs/awaiter.rs
@@ -57,7 +57,7 @@ impl<Data: std::marker::Unpin> PromiseAwaiter<Data> {
             let node = this.node.take();
 
             // Safety: `awaiter` stores `rust_waker_ptr` and uses it to call `wake()`. Note that
-            // `awaiter` is `this.awaiter`, which lives before `this.option_waker`. 
+            // `awaiter` is `this.awaiter`, which lives before `this.option_waker`.
             // Since we drop awaiter manually, the `rust_waker_ptr` that `awaiter` stores will always
             // be valid during its lifetime.
             //
@@ -69,7 +69,9 @@ impl<Data: std::marker::Unpin> PromiseAwaiter<Data> {
             // Safety: The memory slot is valid and this type ensures that it will stay pinned.
             unsafe {
                 crate::ffi::guarded_rust_promise_awaiter_new_in_place(
-                    this.awaiter.as_mut_ptr().cast::<GuardedRustPromiseAwaiter>(),
+                    this.awaiter
+                        .as_mut_ptr()
+                        .cast::<GuardedRustPromiseAwaiter>(),
                     rust_waker_ptr,
                     node.expect("node should be Some in call to init()"),
                 );
@@ -98,7 +100,9 @@ impl<Data: std::marker::Unpin> Drop for PromiseAwaiter<Data> {
         if self.awaiter_initialized {
             unsafe {
                 crate::ffi::guarded_rust_promise_awaiter_drop_in_place(
-                    self.awaiter.as_mut_ptr().cast::<GuardedRustPromiseAwaiter>()
+                    self.awaiter
+                        .as_mut_ptr()
+                        .cast::<GuardedRustPromiseAwaiter>(),
                 );
             }
         }

--- a/kj-rs/lib.rs
+++ b/kj-rs/lib.rs
@@ -12,9 +12,9 @@ pub use promise::new_callbacks_promise_future;
 
 mod awaiter;
 mod future;
+mod own;
 mod promise;
 mod waker;
-mod own;
 
 pub mod repr {
     pub use crate::future::repr::*;

--- a/kj-rs/own.c++
+++ b/kj-rs/own.c++
@@ -5,7 +5,7 @@ extern "C" {
 // This works because disposers work by virtual call, and the disposer is created during creation of
 // the Own, so the type of the Own at destruction doesn't actually matter for Owns that do not use a
 // static disposer, which are not currently supported by workerd-cxx.
-void cxxbridge$kjrs$own$drop(void *own) {
-  reinterpret_cast<kj::Own<void> *>(own)->~Own();
+void cxxbridge$kjrs$own$drop(void* own) {
+  reinterpret_cast<kj::Own<void>*>(own)->~Own();
 }
 }

--- a/kj-rs/own.h
+++ b/kj-rs/own.h
@@ -3,5 +3,5 @@
 #include <kj/memory.h>
 
 extern "C" {
-    void cxxbridge$kjrs$own$drop(void* own);
+void cxxbridge$kjrs$own$drop(void* own);
 }

--- a/kj-rs/tests/BUILD.bazel
+++ b/kj-rs/tests/BUILD.bazel
@@ -13,7 +13,7 @@ platform(
 )
 
 rust_library(
-    name = "awaitables-rust",
+    name = "tests",
     srcs = glob(["*.rs"]),
     edition = "2024",
     deps = [
@@ -28,13 +28,13 @@ rust_unpretty(
     name = "expand-rust_test",
     testonly = True,
     deps = [
-        ":awaitables-rust_test"
+        ":rust_tests"
     ]
 )
 
 rust_test(
-    name = "awaitables-rust_test",
-    crate = "awaitables-rust",
+    name = "rust_tests",
+    crate = "tests",
     deps = [
         ":test-promises",
     ],
@@ -80,7 +80,7 @@ cc_test(
         "//conditions:default": False,
     }),
     deps = [
-        ":awaitables-rust",
+        ":tests",
         ":bridge",
         ":test-promises",
         "//third-party:runtime",

--- a/kj-rs/tests/lib.rs
+++ b/kj-rs/tests/lib.rs
@@ -49,17 +49,26 @@ mod ffi {
         #[cxx_name = "setData"]
         fn set_data(self: Pin<&mut OpaqueCxxClass>, val: u64);
 
+        #[allow(dead_code)]
         fn cxx_kj_own() -> Own<OpaqueCxxClass>;
         fn null_kj_own() -> Own<OpaqueCxxClass>;
+        #[allow(dead_code)]
         fn give_own_back(own: Own<OpaqueCxxClass>);
+        #[allow(dead_code)]
         fn modify_own_return_test();
+        #[allow(dead_code)]
         fn breaking_things() -> Own<OpaqueCxxClass>;
 
+        #[allow(dead_code)]
         fn own_integer() -> Own<i64>;
+        #[allow(dead_code)]
         fn own_integer_attached() -> Own<i64>;
 
+        #[allow(dead_code)]
         fn null_exception_test_driver_1() -> String;
+        #[allow(dead_code)]
         fn null_exception_test_driver_2() -> String;
+        #[allow(dead_code)]
         fn rust_take_own_driver();
     }
 

--- a/kj-rs/tests/test-own.c++
+++ b/kj-rs/tests/test-own.c++
@@ -1,15 +1,17 @@
 #include "test-own.h"
+
 #include "kj/string.h"
+
 #include <exception>
 
 namespace kj_rs_demo {
 
-kj::Own<OpaqueCxxClass> cxx_kj_own() { 
-  return kj::heap<OpaqueCxxClass>(42); 
+kj::Own<OpaqueCxxClass> cxx_kj_own() {
+  return kj::heap<OpaqueCxxClass>(42);
 }
 
-kj::Own<OpaqueCxxClass> null_kj_own() { 
-  return kj::Own<OpaqueCxxClass>(); 
+kj::Own<OpaqueCxxClass> null_kj_own() {
+  return kj::Own<OpaqueCxxClass>();
 }
 
 void give_own_back(kj::Own<OpaqueCxxClass> own) {
@@ -42,19 +44,19 @@ kj::Own<int64_t> own_integer_attached() {
 
 rust::string null_exception_test_driver_1() {
   try {
-      auto _ = modify_own_return(null_kj_own());
-      return rust::string("");
-  } catch (const std::exception &e) {
-      return rust::string(e.what());
+    auto _ = modify_own_return(null_kj_own());
+    return rust::string("");
+  } catch (const std::exception& e) {
+    return rust::string(e.what());
   }
 }
 
 rust::string null_exception_test_driver_2() {
   try {
-      auto _ = get_null();
-      return rust::string("");
-  } catch (const std::exception &e) {
-      return rust::string(e.what());
+    auto _ = get_null();
+    return rust::string("");
+  } catch (const std::exception& e) {
+    return rust::string(e.what());
   }
 }
 
@@ -63,4 +65,4 @@ void rust_take_own_driver() {
   take_own(kj::mv(own));
 }
 
-} // namespace kj_rs_demo
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test-own.h
+++ b/kj-rs/tests/test-own.h
@@ -1,21 +1,27 @@
 #pragma once
 
 #include "kj/memory.h"
-#include <cstdint>
-#include <kj/debug.h>
+
 #include <rust/cxx.h>
+
+#include <kj/debug.h>
+
 #include <cstdint>
 
 namespace kj_rs_demo {
 
 class OpaqueCxxClass {
-public:
-  OpaqueCxxClass(uint64_t data) : data(data) {}
+ public:
+  OpaqueCxxClass(uint64_t data): data(data) {}
   ~OpaqueCxxClass() {}
-  uint64_t getData() const { return this->data; }
-  void setData(uint64_t val) { this->data = val; }
+  uint64_t getData() const {
+    return this->data;
+  }
+  void setData(uint64_t val) {
+    this->data = val;
+  }
 
-private:
+ private:
   uint64_t data;
 };
 
@@ -41,4 +47,4 @@ kj::Own<OpaqueCxxClass> breaking_things();
 kj::Own<int64_t> own_integer();
 kj::Own<int64_t> own_integer_attached();
 
-} // namespace kj_rs_demo
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test_own.rs
+++ b/kj-rs/tests/test_own.rs
@@ -119,7 +119,7 @@ pub mod tests {
     #[test]
     fn null_exception_test() {
         assert!(ffi::null_exception_test_driver_1().contains("Cannot pass a null Own to Rust"));
-        assert!(ffi::null_exception_test_driver_2().contains("panic in awaitables_rust::ffi::get_null"));
+        assert!(ffi::null_exception_test_driver_2().contains("panic in tests::ffi::get_null"));
     }
 
     #[test]

--- a/kj-rs/tests/test_own.rs
+++ b/kj-rs/tests/test_own.rs
@@ -106,7 +106,7 @@ pub mod tests {
     #[test]
     #[should_panic]
     fn test_null() {
-        let null_own = ffi::null_kj_own();
+        let _null_own = ffi::null_kj_own();
     }
 
     #[test]

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -733,7 +733,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                         true => quote_spanned!(span=> #call.as_mut_slice::<#inner>()),
                     }
                 }
-                Type::Own(_) => quote_spanned!{span=>
+                Type::Own(_) => quote_spanned! {span=>
                     let __temp = #call;
                     assert!(!__temp.as_ptr().is_null(), "Returning a Null kj::Own to Rust is not valid");
                     __temp

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -166,7 +166,7 @@ impl CxxString {
     /// [replacement character]: char::REPLACEMENT_CHARACTER
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn to_string_lossy(&self) -> Cow<str> {
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.as_bytes())
     }
 

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -155,12 +155,12 @@ where
     }
 
     /// Returns an iterator over elements of type `&T`.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter { v: self, index: 0 }
     }
 
     /// Returns an iterator over elements of type `Pin<&mut T>`.
-    pub fn iter_mut(self: Pin<&mut Self>) -> IterMut<T> {
+    pub fn iter_mut(self: Pin<&mut Self>) -> IterMut<'_, T> {
         IterMut { v: self, index: 0 }
     }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -165,14 +165,17 @@ fn check_type_unique_ptr(cx: &mut Check, ptr: &Ty1) {
 fn check_type_kj_own(cx: &mut Check, ptr: &Ty1) {
     if let Type::Ident(ident) = &ptr.inner {
         if cx.types.rust.contains(&ident.rust) {
-            cx.error(ptr, "kj::Own of a Rust type is not supported yet, use a Box instead");
+            cx.error(
+                ptr,
+                "kj::Own of a Rust type is not supported yet, use a Box instead",
+            );
             return;
         }
 
         match Atom::from(&ident.rust) {
             None => return,
             Some(
-                Bool | U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize | F32 | F64
+                Bool | U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize | F32 | F64,
             ) => {
                 return;
             }

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -28,8 +28,7 @@ impl<'a> Types<'a> {
             | Type::Fn(_)
             | Type::Void(_)
             | Type::SliceRef(_) => Definite(true),
-            Type::UniquePtr(_)
-            | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) => {
+            Type::UniquePtr(_) | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) => {
                 Definite(false)
             }
             Type::Ref(ty) => self.determine_improper_ctype(&ty.inner),

--- a/syntax/instantiate.rs
+++ b/syntax/instantiate.rs
@@ -28,7 +28,7 @@ pub struct NamedImplKey<'a> {
 }
 
 impl Type {
-    pub fn impl_key(&self) -> Option<ImplKey> {
+    pub fn impl_key(&self) -> Option<ImplKey<'_>> {
         if let Type::RustBox(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
                 return Some(ImplKey::RustBox(NamedImplKey::new(ty, ident)));

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -243,8 +243,7 @@ impl<'a> Types<'a> {
 
     pub fn needs_indirect_abi(&self, ty: &Type) -> bool {
         match ty {
-            Type::RustBox(_)
-            | Type::UniquePtr(_) => false,
+            Type::RustBox(_) | Type::UniquePtr(_) => false,
             Type::Array(_) => true,
             Type::Future(_) | Type::Own(_) => true,
             _ => !self.is_guaranteed_pod(ty),


### PR DESCRIPTION
- making clippy configuration fail on warnings, add format checking
- fixed all existing clippy warnings
- rust fmt