### PR TITLE
[workerd-cxx] kj::Own refcount check and reexport

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1654,7 +1654,7 @@ fn write_kj_own(out: &mut OutFile, key: NamedImplKey) {
     );
     writeln!(
         out,
-        "static_assert(!::std::is_base_of<::kj::Refcounted, {}>::value, \"Value must not inherit from kj::Refcounted\");",
+        "static_assert(!kj::_::IsRefcounted<{}>, \"Value must not inherit from kj::Refcounted\");",
         inner
     );
 }

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1654,7 +1654,7 @@ fn write_kj_own(out: &mut OutFile, key: NamedImplKey) {
     );
     writeln!(
         out,
-        "static_assert(!kj::_::IsRefcounted<{}>, \"Value must not inherit from kj::Refcounted\");",
+        "static_assert(!::kj::_::IsRefcounted<{}>, \"Value must not inherit from kj::Refcounted\");",
         inner
     );
 }

--- a/kj-rs/lib.rs
+++ b/kj-rs/lib.rs
@@ -4,6 +4,7 @@ use awaiter::WakerRef;
 pub use crate::ffi::KjWaker;
 pub use awaiter::PromiseAwaiter;
 pub use future::FuturePollStatus;
+pub use own::repr::Own;
 pub use promise::KjPromise;
 pub use promise::KjPromiseNodeImpl;
 pub use promise::OwnPromiseNode;


### PR DESCRIPTION
- Reexport Own as `kj_rs::Own`
- Use KJ IsRefcounted concept to ensure an Own<T> isn't refcounted