### PR TITLE
[workerd-cxx] Add kj::Rc and kj::Arc bindings to kj-rs

### DIFF
--- a/kj-rs/lib.rs
+++ b/kj-rs/lib.rs
@@ -11,18 +11,21 @@ pub use promise::KjPromiseNodeImpl;
 pub use promise::OwnPromiseNode;
 pub use promise::PromiseFuture;
 pub use promise::new_callbacks_promise_future;
+pub use repr::{KjArc, KjRc};
 
 mod awaiter;
 mod future;
 pub mod maybe;
 mod own;
 mod promise;
+pub mod refcount;
 mod waker;
 
 pub mod repr {
     pub use crate::future::repr::*;
     pub use crate::maybe::repr::*;
     pub use crate::own::repr::*;
+    pub use crate::refcount::repr::*;
 }
 
 pub type Result<T> = std::io::Result<T>;

--- a/kj-rs/refcount.rs
+++ b/kj-rs/refcount.rs
@@ -1,0 +1,111 @@
+//! Module for both [`KjRc`] and [`KjArc`], since they're nearly identical types
+
+// Allows using `Refcounted` and `AtomicRefcounted` from `kj_rs::refcounted` as
+// if it was a Rust trait representing a refcounted object.
+pub use repr::{AtomicRefcounted, Refcounted};
+
+pub mod repr {
+    use crate::Own;
+    use std::ops::Deref;
+
+    /// # Safety
+    /// Should only be automatically implemented by the bridge macro
+    pub unsafe trait Refcounted {
+        fn is_shared(&self) -> bool;
+        /// # Safety
+        /// Do not call this function, instead, clone the [`KjRc`].
+        unsafe fn add_ref(rc: &KjRc<Self>) -> KjRc<Self>;
+    }
+
+    /// # Safety
+    /// Should only be automatically implemented by the bridge macro
+    pub unsafe trait AtomicRefcounted {
+        fn is_shared(&self) -> bool;
+        /// # Safety
+        /// Do not call this function, instead, clone the [`KjArc`].
+        unsafe fn add_ref(arc: &KjArc<Self>) -> KjArc<Self>;
+    }
+
+    /// Bindings to the kj type `kj::Rc`. Represents and owned and reference counted type,
+    /// like Rust's [`std::rc::Rc`].
+    #[repr(C)]
+    pub struct KjRc<T: Refcounted + ?Sized> {
+        own: Own<T>,
+    }
+
+    /// Bindings to the kj type `kj::Arc`. Represents and owned and atomically reference
+    /// counted type, like Rust's [`std::sync::Arc`].
+    #[repr(C)]
+    pub struct KjArc<T: AtomicRefcounted + ?Sized> {
+        own: Own<T>,
+    }
+
+    unsafe impl<T: AtomicRefcounted> Send for KjArc<T> where T: Send {}
+    unsafe impl<T: AtomicRefcounted> Sync for KjArc<T> where T: Sync {}
+
+    impl<T: Refcounted> KjRc<T> {
+        #[must_use]
+        pub fn get(&self) -> *const T {
+            self.own.as_ptr()
+        }
+
+        // The return value here represents exclusive access to the internal `Own`.
+        // This allows for exclusive mutation of the inner value.
+        pub fn get_mut(&mut self) -> Option<&mut Own<T>> {
+            if self.own.is_shared() {
+                None
+            } else {
+                Some(&mut self.own)
+            }
+        }
+    }
+
+    impl<T: AtomicRefcounted> KjArc<T> {
+        #[must_use]
+        pub fn get(&self) -> *const T {
+            self.own.as_ptr()
+        }
+
+        // The return value here represents exclusive access to the internal `Own`.
+        // This allows for exclusive mutation of the inner value.
+        pub fn get_mut(&mut self) -> Option<&mut Own<T>> {
+            if self.own.is_shared() {
+                None
+            } else {
+                Some(&mut self.own)
+            }
+        }
+    }
+
+    impl<T: Refcounted> Deref for KjRc<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.own
+        }
+    }
+
+    impl<T: AtomicRefcounted> Deref for KjArc<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.own
+        }
+    }
+
+    /// Using clone to create another count, like how Rust does it.
+    impl<T: Refcounted> Clone for KjRc<T> {
+        fn clone(&self) -> Self {
+            unsafe { T::add_ref(self) }
+        }
+    }
+
+    impl<T: AtomicRefcounted> Clone for KjArc<T> {
+        fn clone(&self) -> Self {
+            unsafe { T::add_ref(self) }
+        }
+    }
+
+    // No `Drop` needs to be implemented for `KjRc` or `KjArc`, because the
+    // internal `Own` `Drop` is sufficient.
+}

--- a/kj-rs/tests/BUILD.bazel
+++ b/kj-rs/tests/BUILD.bazel
@@ -48,7 +48,8 @@ rust_cxx_bridge(
         "test-promises.h",
         "test-maybe.h",
         "test-own.h",
-        "shared.h"
+        "shared.h",
+        "test-refcount.h"
     ],
     include_prefix = "kj-rs-demo",
     deps = [
@@ -60,7 +61,8 @@ cc_library(
     name = "test-promises",
     srcs = [
         "test-promises.c++",
-        "test-own.c++"
+        "test-own.c++",
+        "test-refcount.c++"
     ],
     linkstatic = select({
         "@platforms//os:windows": True,

--- a/kj-rs/tests/test-refcount.c++
+++ b/kj-rs/tests/test-refcount.c++
@@ -1,0 +1,24 @@
+#include "test-refcount.h"
+
+#include "kj-rs-demo/lib.rs.h"
+#include "kj-rs/tests/lib.rs.h"
+#include "kj/common.h"
+#include "kj/debug.h"
+
+namespace kj_rs_demo {
+kj::Rc<OpaqueRefcountedClass> get_rc() {
+  return kj::rc<OpaqueRefcountedClass>(15);
+}
+
+kj::Arc<OpaqueAtomicRefcountedClass> get_arc() {
+  return kj::arc<OpaqueAtomicRefcountedClass>(16);
+}
+void give_arc_back(kj::Arc<OpaqueAtomicRefcountedClass> arc) {
+  kj::Arc<OpaqueAtomicRefcountedClass> ret_arc = modify_own_ret_arc(kj::mv(arc));
+  KJ_ASSERT(ret_arc->getData() == 328);
+}
+void give_rc_back(kj::Rc<OpaqueRefcountedClass> rc) {
+  kj::Rc<OpaqueRefcountedClass> ret_rc = modify_own_ret_rc(kj::mv(rc));
+  KJ_ASSERT(ret_rc->getData() == 467);
+}
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test-refcount.h
+++ b/kj-rs/tests/test-refcount.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "kj/refcount.h"
+
+#include <cstdint>
+
+namespace kj_rs_demo {
+
+class OpaqueRefcountedClass: public kj::Refcounted {
+ public:
+  OpaqueRefcountedClass(uint64_t data): data(data) {}
+  ~OpaqueRefcountedClass() {}
+  uint64_t getData() const {
+    return this->data;
+  }
+  void setData(uint64_t val) {
+    this->data = val;
+  }
+
+ private:
+  uint64_t data;
+};
+
+class OpaqueAtomicRefcountedClass: public kj::AtomicRefcounted {
+ public:
+  OpaqueAtomicRefcountedClass(uint64_t data): data(data) {}
+  ~OpaqueAtomicRefcountedClass() {}
+  uint64_t getData() const {
+    return this->data;
+  }
+  void setData(uint64_t val) {
+    this->data = val;
+  }
+
+ private:
+  uint64_t data;
+};
+
+kj::Rc<OpaqueRefcountedClass> get_rc();
+kj::Arc<OpaqueAtomicRefcountedClass> get_arc();
+
+void give_arc_back(kj::Arc<OpaqueAtomicRefcountedClass> arc);
+void give_rc_back(kj::Rc<OpaqueRefcountedClass> rc);
+
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test_refcount.rs
+++ b/kj-rs/tests/test_refcount.rs
@@ -1,0 +1,86 @@
+use crate::ffi;
+use kj_rs::{KjArc, KjRc};
+
+pub fn modify_own_ret_rc(
+    mut rc: KjRc<ffi::OpaqueRefcountedClass>,
+) -> KjRc<ffi::OpaqueRefcountedClass> {
+    let mut_ref = rc.get_mut();
+    mut_ref.unwrap().pin_mut().set_data(467);
+    rc
+}
+
+pub fn modify_own_ret_arc(
+    mut arc: KjArc<ffi::OpaqueAtomicRefcountedClass>,
+) -> KjArc<ffi::OpaqueAtomicRefcountedClass> {
+    let mut_ref = arc.get_mut();
+    mut_ref.unwrap().pin_mut().set_data(328);
+    arc
+}
+
+#[cfg(test)]
+pub mod tests {
+    use kj_rs::refcount::{AtomicRefcounted, Refcounted};
+
+    use crate::ffi;
+
+    #[test]
+    fn test_rc() {
+        let rc = ffi::get_rc();
+        assert_eq!(rc.get_data(), 15);
+        let rc_clone = rc.clone();
+        assert_eq!(rc_clone.get_data(), 15);
+
+        assert!(rc.is_shared());
+        std::mem::drop(rc_clone);
+        assert!(!rc.is_shared());
+    }
+
+    #[test]
+    fn test_arc() {
+        let arc = ffi::get_arc();
+        assert_eq!(arc.get_data(), 16);
+        let arc_clone = arc.clone();
+        assert_eq!(arc_clone.get_data(), 16);
+
+        assert!(arc.is_shared());
+        std::mem::drop(arc_clone);
+        assert!(!arc.is_shared());
+    }
+
+    #[test]
+    fn test_pass_cxx() {
+        let rc = ffi::get_rc();
+        let arc = ffi::get_arc();
+        ffi::give_rc_back(rc);
+        ffi::give_arc_back(arc);
+    }
+
+    #[test]
+    fn test_arc_thread() {
+        let mut arc = ffi::get_arc();
+
+        std::thread::scope(|s| {
+            let mut c = arc.clone();
+            assert!(c.get_mut().is_none());
+
+            s.spawn(|| {
+                assert_eq!(arc.clone().get_data(), 16);
+            });
+
+            s.spawn(|| {
+                let a = arc.clone();
+                assert!(a.is_shared());
+            });
+        });
+
+        {
+            let mut cloned = arc.clone();
+            assert!(cloned.get_mut().is_none());
+        }
+
+        let mut_ref = arc.get_mut();
+        assert!(mut_ref.is_some());
+        mut_ref.unwrap().pin_mut().set_data(35643);
+        assert_eq!(arc.get_data(), 35643);
+    }
+}

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -73,6 +73,8 @@ fn check_type(cx: &mut Check, ty: &Type) {
         Type::RustVec(ty) => check_type_rust_vec(cx, ty),
         Type::UniquePtr(ptr) => check_type_unique_ptr(cx, ptr),
         Type::Own(ptr) => check_type_kj_own(cx, ptr),
+        Type::KjRc(ptr) => check_type_kj_rc(cx, ptr),
+        Type::KjArc(ptr) => check_type_kj_arc(cx, ptr),
         Type::SharedPtr(ptr) => check_type_shared_ptr(cx, ptr),
         Type::WeakPtr(ptr) => check_type_weak_ptr(cx, ptr),
         Type::CxxVector(ptr) => check_type_cxx_vector(cx, ptr),
@@ -186,6 +188,41 @@ fn check_type_kj_own(cx: &mut Check, ptr: &Ty1) {
     }
 
     cx.error(ptr, "unsupported kj::Own target type");
+}
+fn check_type_kj_rc(cx: &mut Check, ptr: &Ty1) {
+    if let Type::Ident(ident) = &ptr.inner {
+        if cx.types.rust.contains(&ident.rust) {
+            cx.error(
+                ptr,
+                "kj::Rc of a Rust type is not supported yet, use a Box instead",
+            );
+            return;
+        }
+
+        if Atom::from(&ident.rust).is_none() {
+            return;
+        }
+    }
+
+    cx.error(ptr, "unsupported KjRc target type");
+}
+
+fn check_type_kj_arc(cx: &mut Check, ptr: &Ty1) {
+    if let Type::Ident(ident) = &ptr.inner {
+        if cx.types.rust.contains(&ident.rust) {
+            cx.error(
+                ptr,
+                "kj::Arc of a Rust type is not supported yet, use a Box instead",
+            );
+            return;
+        }
+
+        if Atom::from(&ident.rust).is_none() {
+            return;
+        }
+    }
+
+    cx.error(ptr, "unsupported KjArc target type");
 }
 
 fn check_type_shared_ptr(cx: &mut Check, ptr: &Ty1) {
@@ -749,6 +786,8 @@ fn is_unsized(cx: &mut Check, ty: &Type) -> bool {
         | Type::RustVec(_)
         | Type::UniquePtr(_)
         | Type::Own(_)
+        | Type::KjRc(_)
+        | Type::KjArc(_)
         | Type::SharedPtr(_)
         | Type::WeakPtr(_)
         | Type::Maybe(_)
@@ -826,6 +865,8 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
         Type::RustVec(_) => "Vec".to_owned(),
         Type::UniquePtr(_) => "unique_ptr".to_owned(),
         Type::Own(_) => "kj::Own".to_owned(),
+        Type::KjRc(_) => "kj::Rc".to_owned(),
+        Type::KjArc(_) => "kj::Arc".to_owned(),
         Type::SharedPtr(_) => "shared_ptr".to_owned(),
         Type::WeakPtr(_) => "weak_ptr".to_owned(),
         Type::Maybe(_) => "kj::Maybe".to_owned(),

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -48,6 +48,8 @@ impl Hash for Type {
             Type::RustBox(t) => t.hash(state),
             Type::UniquePtr(t) => t.hash(state),
             Type::Own(t) => t.hash(state),
+            Type::KjRc(t) => t.hash(state),
+            Type::KjArc(t) => t.hash(state),
             Type::SharedPtr(t) => t.hash(state),
             Type::WeakPtr(t) => t.hash(state),
             Type::Ref(t) => t.hash(state),

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -35,7 +35,9 @@ impl<'a> Types<'a> {
             Type::Ptr(ty) => self.determine_improper_ctype(&ty.inner),
             Type::Array(ty) => self.determine_improper_ctype(&ty.inner),
             Type::Maybe(ty) => self.determine_improper_ctype(&ty.inner),
-            Type::Future(_) | Type::Own(_) => todo!("file a workerd-cxx ticket"),
+            Type::Future(_) | Type::Own(_) | Type::KjRc(_) | Type::KjArc(_) => {
+                todo!("file a workerd-cxx ticket")
+            }
         }
     }
 }

--- a/syntax/instantiate.rs
+++ b/syntax/instantiate.rs
@@ -10,6 +10,8 @@ pub enum ImplKey<'a> {
     UniquePtr(NamedImplKey<'a>),
     Own(NamedImplKey<'a>),
     Maybe(NamedImplKey<'a>),
+    KjRc(NamedImplKey<'a>),
+    KjArc(NamedImplKey<'a>),
     SharedPtr(NamedImplKey<'a>),
     WeakPtr(NamedImplKey<'a>),
     CxxVector(NamedImplKey<'a>),
@@ -49,6 +51,14 @@ impl Type {
         } else if let Type::Maybe(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
                 return Some(ImplKey::Maybe(NamedImplKey::new(ty, ident)));
+            }
+        } else if let Type::KjRc(ty) = self {
+            if let Type::Ident(ident) = &ty.inner {
+                return Some(ImplKey::KjRc(NamedImplKey::new(ty, ident)));
+            }
+        } else if let Type::KjArc(ty) = self {
+            if let Type::Ident(ident) = &ty.inner {
+                return Some(ImplKey::KjArc(NamedImplKey::new(ty, ident)));
             }
         } else if let Type::SharedPtr(ty) = self {
             if let Type::Ident(ident) = &ty.inner {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -293,6 +293,8 @@ pub enum Type {
     RustVec(Box<Ty1>),
     UniquePtr(Box<Ty1>),
     Own(Box<Ty1>),
+    KjRc(Box<Ty1>),
+    KjArc(Box<Ty1>),
     SharedPtr(Box<Ty1>),
     WeakPtr(Box<Ty1>),
     Ref(Box<Ref>),

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -1058,6 +1058,8 @@ fn parse_impl(cx: &mut Errors, imp: ItemImpl) -> Result<Api> {
         | Type::RustVec(ty)
         | Type::UniquePtr(ty)
         | Type::Own(ty)
+        | Type::KjRc(ty)
+        | Type::KjArc(ty)
         | Type::SharedPtr(ty)
         | Type::WeakPtr(ty)
         | Type::Maybe(ty)
@@ -1231,6 +1233,26 @@ fn parse_type_path(ty: &TypePath) -> Result<Type> {
                     if let GenericArgument::Type(arg) = &generic.args[0] {
                         let inner = parse_type(arg)?;
                         return Ok(Type::Own(Box::new(Ty1 {
+                            name: ident,
+                            langle: generic.lt_token,
+                            inner,
+                            rangle: generic.gt_token,
+                        })));
+                    }
+                } else if ident == "KjRc" && generic.args.len() == 1 {
+                    if let GenericArgument::Type(arg) = &generic.args[0] {
+                        let inner = parse_type(arg)?;
+                        return Ok(Type::KjRc(Box::new(Ty1 {
+                            name: ident,
+                            langle: generic.lt_token,
+                            inner,
+                            rangle: generic.gt_token,
+                        })));
+                    }
+                } else if ident == "KjArc" && generic.args.len() == 1 {
+                    if let GenericArgument::Type(arg) = &generic.args[0] {
+                        let inner = parse_type(arg)?;
+                        return Ok(Type::KjArc(Box::new(Ty1 {
                             name: ident,
                             langle: generic.lt_token,
                             inner,
@@ -1498,6 +1520,8 @@ fn has_references_without_lifetime(ty: &Type) -> bool {
         | Type::RustVec(t)
         | Type::UniquePtr(t)
         | Type::Own(t)
+        | Type::KjRc(t)
+        | Type::KjArc(t)
         | Type::SharedPtr(t)
         | Type::WeakPtr(t)
         | Type::Maybe(t)

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -26,6 +26,8 @@ impl<'a> Types<'a> {
             | Type::RustVec(_)
             | Type::UniquePtr(_)
             | Type::Own(_)
+            | Type::KjRc(_)
+            | Type::KjArc(_)
             | Type::SharedPtr(_)
             | Type::WeakPtr(_)
             | Type::CxxVector(_)

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -27,6 +27,8 @@ impl ToTokens for Type {
             Type::RustBox(ty)
             | Type::UniquePtr(ty)
             | Type::Own(ty)
+            | Type::KjRc(ty)
+            | Type::KjArc(ty)
             | Type::SharedPtr(ty)
             | Type::WeakPtr(ty)
             | Type::CxxVector(ty)
@@ -74,6 +76,12 @@ impl ToTokens for Ty1 {
                 tokens.extend(quote_spanned!(span=> ::cxx::));
             }
             "Own" => {
+                tokens.extend(quote_spanned!(span => ::kj_rs::repr::));
+            }
+            "KjRc" => {
+                tokens.extend(quote_spanned!(span => ::kj_rs::repr::));
+            }
+            "KjArc" => {
                 tokens.extend(quote_spanned!(span => ::kj_rs::repr::));
             }
             "Box" => {

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -179,6 +179,8 @@ impl<'a> Types<'a> {
                 | ImplKey::RustVec(ident)
                 | ImplKey::UniquePtr(ident)
                 | ImplKey::Own(ident)
+                | ImplKey::KjRc(ident)
+                | ImplKey::KjArc(ident)
                 | ImplKey::SharedPtr(ident)
                 | ImplKey::WeakPtr(ident)
                 | ImplKey::Maybe(ident)

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -15,6 +15,8 @@ where
         Type::RustBox(ty)
         | Type::UniquePtr(ty)
         | Type::Own(ty)
+        | Type::KjRc(ty)
+        | Type::KjArc(ty)
         | Type::SharedPtr(ty)
         | Type::WeakPtr(ty)
         | Type::CxxVector(ty)


### PR DESCRIPTION
Adds simple `kj::Rc` and `kj::Arc` bindings to Rust. 