### PR TITLE
[workerd-cxx] cleanup core library

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,7 @@ rust_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":core-lib",
+        ":core",
         "@crates.io//:foldhash",
     ],
 )
@@ -70,17 +70,12 @@ rust_binary(
 
 cc_library(
     name = "core",
-    hdrs = ["include/cxx.h"],
-    include_prefix = "rust",
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "core-lib",
     srcs = ["src/cxx.cc"],
     hdrs = ["include/cxx.h"],
+    include_prefix = "rust",
     linkstatic = True,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
 )
 
 rust_proc_macro(

--- a/kj-rs/BUILD.bazel
+++ b/kj-rs/BUILD.bazel
@@ -35,22 +35,8 @@ rust_cxx_bridge(
     hdrs = glob(["*.h"]),
     include_prefix = "kj-rs",
     deps = [
-        ":cxx",
         "@capnp-cpp//src/kj:kj",
         "@capnp-cpp//src/kj:kj-async",
-        "@workerd-cxx//:cxx",
+        "@workerd-cxx//:core",
     ],
-)
-
-genrule(
-    name = "cxx/generated",
-    outs = ["cxx.h"],
-    cmd = "$(location @workerd-cxx//:codegen) --header > \"$@\"",
-    tools = ["@workerd-cxx//:codegen"],
-)
-
-cc_library(
-    name = "cxx",
-    hdrs = ["cxx.h"],
-    include_prefix = "rust",
 )


### PR DESCRIPTION
I want to switch downstream from generated headers to direct bazel target consumption.