### PR TITLE
[workerd-cxx] cleanup: removing alloc and std features

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,10 +4,6 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_mac
 rust_library(
     name = "cxx",
     srcs = glob(["src/**/*.rs"]),
-    crate_features = [
-        "alloc",
-        "std",
-    ],
     edition = "2021",
     proc_macro_deps = [
         ":cxxbridge-macro",

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -1,8 +1,8 @@
 use crate::actually_private::Private;
 use crate::lossy;
-#[cfg(feature = "alloc")]
+
 use alloc::borrow::Cow;
-#[cfg(feature = "alloc")]
+
 use alloc::string::String;
 use core::cmp::Ordering;
 use core::ffi::{c_char, CStr};
@@ -164,8 +164,6 @@ impl CxxString {
     /// Cow::Owned String.
     ///
     /// [replacement character]: char::REPLACEMENT_CHARACTER
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_string_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.as_bytes())
     }
@@ -281,7 +279,6 @@ impl fmt::Write for Pin<&mut CxxString> {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::io::Write for Pin<&mut CxxString> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.as_mut().push_bytes(buf);

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,9 +4,6 @@ use core::{
     ptr::NonNull,
 };
 
-#[cfg(error_in_core)]
-use core::error::Error as StdError;
-#[cfg(all(feature = "std", not(error_in_core)))]
 use core::error::Error as StdError;
 
 // Representation for kj::Exception* and functions to manipulated it,
@@ -37,7 +34,6 @@ pub(crate) mod repr {
 }
 
 /// Exception thrown from an `extern "C++"` function.
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Debug)]
 pub struct Exception {
     pub(crate) err: NonNull<repr::KjException>,
@@ -52,7 +48,6 @@ impl Display for Exception {
     }
 }
 
-#[cfg(any(error_in_core, feature = "std"))]
 impl StdError for Exception {}
 
 impl Exception {

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -1,6 +1,6 @@
 use self::kind::{Kind, Opaque, Trivial};
 use crate::CxxString;
-#[cfg(feature = "alloc")]
+
 use alloc::string::String;
 
 /// A type for which the layout is determined by its C++ definition.
@@ -216,8 +216,7 @@ impl_extern_type! {
     f32 = "float"
     f64 = "double"
 
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+
     String = "rust::String"
 
     [Opaque]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,36 +403,11 @@ extern crate self as cxx;
 #[doc(hidden)]
 pub extern crate core;
 
-#[cfg(feature = "alloc")]
 #[doc(hidden)]
 pub extern crate alloc;
 
-#[cfg(not(feature = "alloc"))]
-extern crate core as alloc;
-
-#[cfg(feature = "std")]
 #[doc(hidden)]
 pub extern crate std;
-
-// Block inadvertent use of items from libstd, which does not otherwise produce
-// a compile-time error on edition 2018+.
-#[cfg(not(feature = "std"))]
-extern crate core as std;
-
-#[cfg(not(any(feature = "alloc", cxx_experimental_no_alloc)))]
-compile_error! {
-    r#"cxx support for no_alloc is incomplete and semver exempt; you must build with at least one of feature="std", feature="alloc", or RUSTFLAGS='--cfg cxx_experimental_no_alloc'"#
-}
-
-#[cfg(all(compile_error_if_alloc, feature = "alloc"))]
-compile_error! {
-    r#"feature="alloc" is unexpectedly enabled"#
-}
-
-#[cfg(all(compile_error_if_std, feature = "std"))]
-compile_error! {
-    r#"feature="std" is unexpectedly enabled"#
-}
 
 #[macro_use]
 mod macros;
@@ -463,8 +438,6 @@ pub mod vector;
 mod weak_ptr;
 
 pub use crate::cxx_vector::CxxVector;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;
@@ -495,23 +468,23 @@ pub mod private {
     pub use crate::function::FatFunction;
     pub use crate::hash::hash;
     pub use crate::opaque::Opaque;
-    #[cfg(feature = "alloc")]
+
     pub use crate::result::{r#try, Result};
     pub use crate::rust_slice::RustSlice;
     pub use crate::rust_str::RustStr;
-    #[cfg(feature = "alloc")]
+
     pub use crate::rust_string::RustString;
     pub use crate::rust_type::{verify_rust_type, ImplBox, ImplVec, RustType};
-    #[cfg(feature = "alloc")]
+
     pub use crate::rust_vec::RustVec;
     pub use crate::shared_ptr::SharedPtrTarget;
     pub use crate::string::StackString;
     pub use crate::unique_ptr::UniquePtrTarget;
-    #[cfg(feature = "std")]
+
     pub use crate::unwind::catch_unwind;
-    #[cfg(feature = "std")]
+
     pub use crate::unwind::prevent_unwind;
-    #[cfg(feature = "std")]
+
     pub use crate::unwind::try_unwind;
     pub use crate::weak_ptr::WeakPtrTarget;
     pub use core::{concat, module_path};

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "alloc")]
 #![allow(missing_docs)]
 
 use crate::exception::repr;

--- a/src/rust_string.rs
+++ b/src/rust_string.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "alloc")]
 #![allow(missing_docs)]
 
 use alloc::string::String;

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "alloc")]
 #![allow(missing_docs)]
 
 use crate::rust_string::RustString;

--- a/src/symbols/rust_str.rs
+++ b/src/symbols/rust_str.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::mem::MaybeUninit;
 use core::ptr;
@@ -11,7 +10,6 @@ unsafe extern "C" fn str_new(this: &mut MaybeUninit<&str>) {
     unsafe { ptr::write(this, "") }
 }
 
-#[cfg(feature = "alloc")]
 #[export_name = "cxxbridge1$str$ref"]
 unsafe extern "C" fn str_ref<'a>(this: &mut MaybeUninit<&'a str>, string: &'a String) {
     let this = this.as_mut_ptr();

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "alloc")]
-
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use core::mem::{ManuallyDrop, MaybeUninit};

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "alloc")]
-
 use crate::rust_string::RustString;
 use crate::rust_vec::RustVec;
 use alloc::vec::Vec;

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -3,9 +3,9 @@ use crate::fmt::display;
 use crate::kind::Trivial;
 use crate::string::CxxString;
 use crate::ExternType;
-#[cfg(feature = "std")]
+
 use alloc::string::String;
-#[cfg(feature = "std")]
+
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::ffi::c_void;
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
-#[cfg(feature = "std")]
+
 use std::io::{self, IoSlice, Read, Seek, SeekFrom, Write};
 
 /// Binding to C++ `std::unique_ptr<T, std::default_delete<T>>`.
@@ -251,7 +251,6 @@ where
 /// Forwarding `Read` trait implementation in a manner similar to `Box<T>`.
 ///
 /// Note that the implementation will panic for null `UniquePtr<T>`.
-#[cfg(feature = "std")]
 impl<T> Read for UniquePtr<T>
 where
     for<'a> Pin<&'a mut T>: Read,
@@ -284,7 +283,6 @@ where
 /// Forwarding `Seek` trait implementation in a manner similar to `Box<T>`.
 ///
 /// Note that the implementation will panic for null `UniquePtr<T>`.
-#[cfg(feature = "std")]
 impl<T> Seek for UniquePtr<T>
 where
     for<'a> Pin<&'a mut T>: Seek,
@@ -319,7 +317,6 @@ where
 /// Forwarding `Write` trait implementation in a manner similar to `Box<T>`.
 ///
 /// Note that the implementation will panic for null `UniquePtr<T>`.
-#[cfg(feature = "std")]
 impl<T> Write for UniquePtr<T>
 where
     for<'a> Pin<&'a mut T>: Write,

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -41,7 +41,6 @@ impl Drop for Guard {
 }
 
 /// Run the void `foreign_call`, intercepting panics and converting them to errors.
-#[cfg(feature = "std")]
 pub fn catch_unwind<F>(label: &'static str, foreign_call: F) -> ::cxx::result::Result
 where
     F: FnOnce(),
@@ -53,7 +52,6 @@ where
 }
 
 /// Run the error-returning `foreign_call`, intercepting panics and converting them to errors.
-#[cfg(feature = "std")]
 pub fn try_unwind<F>(label: &'static str, foreign_call: F) -> ::cxx::private::Result
 where
     F: FnOnce() -> ::cxx::private::Result,
@@ -64,7 +62,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 fn panic_result(
     label: &'static str,
     err: &alloc::boxed::Box<dyn core::any::Any + Send>,


### PR DESCRIPTION
we always have them on and we've been ignoring them in our code, just remove them