### PR TITLE
[workerd-cxx] kj::Date support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         if: matrix.os.name == 'macos'
         run: sudo xcode-select -s "/Applications/Xcode_16.3.app"
       - run: bazel --version
-      - run: bazel test ... --verbose_failures ${{matrix.os.name == 'macos' && '--xcode_version_config=tools/bazel:github_actions_xcodes' || ''}}
+      - run: bazel test ... --verbose_failures --test_output=errors ${{matrix.os.name == 'macos' && '--xcode_version_config=tools/bazel:github_actions_xcodes' || ''}}
 
 
   clippy:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install lld
-      - run: bazel test --config=asan ... --verbose_failures
+      - run: bazel test --config=asan ... --verbose_failures --test_output=errors
 
   clang-tidy:
     name: Clang Tidy

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following smart pointers can be used in ffi layers:
 ### KJ Data Structures Integration
 
 - `kj::Maybe<T>` - corresponds to `kj_rs::KjMaybe<T>`.
+- `kj::Date` - corresponds to `kj_rs::KjDate`.
 
 ### KJ/Rust conversion layer
 

--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -43,6 +43,7 @@ pub struct Includes<'a> {
     pub basetsd: bool,
     pub sys_types: bool,
     pub content: Content<'a>,
+    pub kj_date: bool,
     pub kj_rs: bool,
     pub jsg: bool,
 }
@@ -107,6 +108,7 @@ pub fn write(out: &mut OutFile) {
         vector,
         basetsd,
         sys_types,
+        kj_date,
         kj_rs,
         jsg,
         content: _,
@@ -189,6 +191,9 @@ pub fn write(out: &mut OutFile) {
         writeln!(out, "#if __cplusplus >= 202002L");
         writeln!(out, "#include <ranges>");
         writeln!(out, "#endif");
+    }
+    if kj_date && !cxx_header {
+        writeln!(out, "#include \"kj-rs/date.h\"");
     }
     if kj_rs && !cxx_header {
         writeln!(out, "#include \"kj-rs/kj-rs.h\"");

--- a/kj-rs/convert.h
+++ b/kj-rs/convert.h
@@ -268,7 +268,6 @@ struct RustCopy {
     return from(&ptr);
   }
 
-
   /// from<RustCopy>(rustSliceOfStrs) - Copy slice of strs to null-terminated KJ strings
   static kj::Array<kj::String> into(::rust::Slice<::rust::str> slice) {
     auto res = kj::heapArrayBuilder<kj::String>(slice.size());

--- a/kj-rs/date.h
+++ b/kj-rs/date.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <kj/time.h>
+
+#include <cstdint>
+
+namespace kj_rs {
+namespace repr {
+
+inline std::int64_t toNanos(kj::Date date) {
+  return (date - kj::origin<kj::Date>()) / kj::NANOSECONDS;
+}
+
+inline kj::Date fromNanos(std::int64_t nanos) {
+  return kj::origin<kj::Date>() + (nanos * kj::NANOSECONDS);
+}
+
+}  // namespace repr
+}  // namespace kj_rs

--- a/kj-rs/date.rs
+++ b/kj-rs/date.rs
@@ -1,0 +1,126 @@
+use core::fmt;
+use std::time::{Duration, SystemTime};
+
+/// Represents a `kj::Date` from the KJ library.
+///
+/// Like C++ represents a point in time as nanoseconds since the Unix epoch (January 1, 1970 UTC).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KjDate {
+    /// Nanoseconds since Unix epoch (January 1, 1970 UTC)
+    nanoseconds: i64,
+}
+
+impl KjDate {
+    /// Creates a new `KjDate` representing the Unix epoch (January 1, 1970 UTC).
+    #[inline]
+    #[must_use]
+    pub const fn unix_epoch() -> Self {
+        Self { nanoseconds: 0 }
+    }
+
+    /// Returns the nanoseconds since Unix epoch.
+    /// This is the only public accessor method needed.
+    #[inline]
+    #[must_use]
+    pub const fn nanoseconds(&self) -> i64 {
+        self.nanoseconds
+    }
+}
+
+impl Default for KjDate {
+    /// Returns the Unix epoch as the default date.
+    fn default() -> Self {
+        Self::unix_epoch()
+    }
+}
+
+impl fmt::Debug for KjDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "KjDate({:?})",
+            std::convert::Into::<SystemTime>::into(*self)
+        )
+    }
+}
+
+impl From<i64> for KjDate {
+    #[inline]
+    fn from(nanoseconds: i64) -> Self {
+        Self { nanoseconds }
+    }
+}
+
+impl From<KjDate> for i64 {
+    #[inline]
+    fn from(date: KjDate) -> Self {
+        date.nanoseconds
+    }
+}
+
+impl From<SystemTime> for KjDate {
+    fn from(time: SystemTime) -> Self {
+        match time.duration_since(std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let nanoseconds = i64::try_from(duration.as_nanos()).unwrap_or(i64::MAX);
+                Self { nanoseconds }
+            }
+            Err(err) => {
+                let duration_before = err.duration();
+                let nanoseconds = -(i64::try_from(duration_before.as_nanos()).unwrap_or(i64::MAX));
+                Self { nanoseconds }
+            }
+        }
+    }
+}
+
+impl From<KjDate> for SystemTime {
+    fn from(date: KjDate) -> Self {
+        let duration =
+            Duration::from_nanos(u64::try_from(date.nanoseconds.abs()).unwrap_or(u64::MAX));
+
+        if date.nanoseconds >= 0 {
+            std::time::UNIX_EPOCH + duration
+        } else {
+            std::time::UNIX_EPOCH - duration
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unix_epoch() {
+        let epoch = KjDate::unix_epoch();
+        assert_eq!(epoch.nanoseconds(), 0);
+    }
+
+    #[test]
+    fn test_from_nanoseconds() {
+        let date = KjDate::from_nanoseconds(1000000000);
+        assert_eq!(date.nanoseconds(), 1000000000);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let earlier = KjDate::from_nanoseconds(1000);
+        let later = KjDate::from_nanoseconds(2000);
+        assert!(earlier < later);
+    }
+
+    #[test]
+    fn test_default() {
+        let default_date = KjDate::default();
+        assert_eq!(default_date, KjDate::unix_epoch());
+    }
+
+    #[test]
+    fn test_system_time_conversion() {
+        let date = KjDate::from_nanoseconds(1000000000);
+        let system_time = date.to_system_time();
+        let converted_back = KjDate::from(system_time);
+        assert_eq!(date, converted_back);
+    }
+}

--- a/kj-rs/lib.rs
+++ b/kj-rs/lib.rs
@@ -3,6 +3,7 @@ use awaiter::WakerRef;
 
 pub use crate::ffi::KjWaker;
 pub use awaiter::PromiseAwaiter;
+pub use date::KjDate;
 pub use future::FuturePollStatus;
 pub use maybe::repr::KjMaybe;
 pub use own::repr::KjOwn;
@@ -11,9 +12,10 @@ pub use promise::KjPromiseNodeImpl;
 pub use promise::OwnPromiseNode;
 pub use promise::PromiseFuture;
 pub use promise::new_callbacks_promise_future;
-pub use repr::{KjArc, KjRc};
+pub use refcount::repr::{KjArc, KjRc};
 
 mod awaiter;
+mod date;
 mod future;
 pub mod maybe;
 mod own;

--- a/kj-rs/tests/BUILD.bazel
+++ b/kj-rs/tests/BUILD.bazel
@@ -18,6 +18,9 @@ rust_library(
     edition = "2024",
     deps = [
         ":bridge",
+        ":test-date",
+        ":test-promises",
+        ":test-maybe",
         # TODO(now): Why isn't :cxx transitive?
         "@workerd-cxx//:cxx",
         "//kj-rs",
@@ -28,28 +31,24 @@ rust_unpretty(
     name = "expand-rust_test",
     testonly = True,
     deps = [
-        ":rust_tests"
-    ]
+        ":rust_tests",
+    ],
 )
 
 rust_test(
     name = "rust_tests",
     crate = "tests",
-    deps = [
-        ":test-promises",
-        ":test-maybe",
-    ],
 )
 
 rust_cxx_bridge(
     name = "bridge",
     src = "lib.rs",
     hdrs = [
-        "test-promises.h",
+        "shared.h",
         "test-maybe.h",
         "test-own.h",
-        "shared.h",
-        "test-refcount.h"
+        "test-promises.h",
+        "test-refcount.h",
     ],
     include_prefix = "kj-rs-demo",
     deps = [
@@ -60,9 +59,9 @@ rust_cxx_bridge(
 cc_library(
     name = "test-promises",
     srcs = [
-        "test-promises.c++",
         "test-own.c++",
-        "test-refcount.c++"
+        "test-promises.c++",
+        "test-refcount.c++",
     ],
     linkstatic = select({
         "@platforms//os:windows": True,
@@ -89,6 +88,36 @@ cc_library(
     ],
 )
 
+rust_cxx_bridge(
+    name = "test-date-bridge",
+    src = "test_date.rs",
+    hdrs = [
+        "test-date.h",
+    ],
+    include_prefix = "kj-rs-demo",
+    deps = [
+        "//kj-rs",
+    ],
+)
+
+cc_library(
+    name = "test-date",
+    srcs = [
+        "test-date.c++",
+    ],
+    hdrs = [
+        "test-date.h",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test-date-bridge",
+    ],
+)
+
 cc_test(
     name = "awaitables-cc-test",
     size = "medium",
@@ -100,10 +129,8 @@ cc_test(
         "//conditions:default": False,
     }),
     deps = [
-        ":tests",
         ":bridge",
-        ":test-promises",
-        ":test-maybe",
+        ":tests",
         "//third-party:runtime",
         "@capnp-cpp//src/kj:kj-test",
     ],
@@ -120,6 +147,24 @@ cc_test(
         "//conditions:default": False,
     }),
     deps = [
+        "//kj-rs",
+        "//third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)
+
+cc_test(
+    name = "date-test",
+    size = "small",
+    srcs = [
+        "date-test.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    deps = [
+        ":tests",
         "//kj-rs",
         "//third-party:runtime",
         "@capnp-cpp//src/kj:kj-test",

--- a/kj-rs/tests/convert-test.c++
+++ b/kj-rs/tests/convert-test.c++
@@ -295,11 +295,11 @@ KJ_TEST("kj::LiteralStringConst as<RustCopy> conversion") {
 KJ_TEST("RustUncheckedUtf8 - Valid UTF-8 conversion") {
   // Test with valid UTF-8 strings
   kj::String kjStr = kj::str("Valid UTF-8: 🚀 测试");
-  
+
   auto rustString = kjStr.as<RustUncheckedUtf8>();
-  
+
   KJ_EXPECT(rustString.size() == kjStr.size());
-  
+
   // Convert back and verify
   auto convertedBack = kj::str(rustString);
   KJ_EXPECT(convertedBack == kjStr);
@@ -307,9 +307,9 @@ KJ_TEST("RustUncheckedUtf8 - Valid UTF-8 conversion") {
 
 KJ_TEST("RustCopyUncheckedUtf8 - StringPtr conversion") {
   kj::StringPtr kjStrPtr = "UTF-8 StringPtr: café";
-  
+
   auto rustString = kjStrPtr.as<RustCopyUncheckedUtf8>();
-  
+
   KJ_EXPECT(rustString.size() == kjStrPtr.size());
   auto convertedBack = kj::str(rustString);
   KJ_EXPECT(convertedBack == kjStrPtr);
@@ -317,9 +317,9 @@ KJ_TEST("RustCopyUncheckedUtf8 - StringPtr conversion") {
 
 KJ_TEST("RustCopyUncheckedUtf8 - ConstString conversion") {
   kj::ConstString kjConstStr = "UTF-8 ConstString: 日本語"_kjc;
-  
+
   auto rustString = kjConstStr.as<RustCopyUncheckedUtf8>();
-  
+
   KJ_EXPECT(rustString.size() == kjConstStr.size());
   auto convertedBack = kj::str(rustString);
   KJ_EXPECT(convertedBack == kjConstStr);
@@ -327,9 +327,9 @@ KJ_TEST("RustCopyUncheckedUtf8 - ConstString conversion") {
 
 KJ_TEST("RustUncheckedUtf8 - StringPtr conversion") {
   kj::StringPtr kjStrPtr = "UTF-8 StringPtr: café";
-  
+
   auto rustStr = kjStrPtr.as<RustUncheckedUtf8>();
-  
+
   KJ_EXPECT(rustStr.size() == kjStrPtr.size());
   auto convertedBack = kj::str(rustStr);
   KJ_EXPECT(convertedBack == kjStrPtr);
@@ -337,9 +337,9 @@ KJ_TEST("RustUncheckedUtf8 - StringPtr conversion") {
 
 KJ_TEST("RustUncheckedUtf8 - ConstString conversion") {
   kj::ConstString kjConstStr = "UTF-8 ConstString: 日本語"_kjc;
-  
+
   auto rustStr = kjConstStr.as<RustUncheckedUtf8>();
-  
+
   KJ_EXPECT(rustStr.size() == kjConstStr.size());
   auto convertedBack = kj::str(rustStr);
   KJ_EXPECT(convertedBack == kjConstStr);

--- a/kj-rs/tests/date-test.c++
+++ b/kj-rs/tests/date-test.c++
@@ -1,0 +1,66 @@
+#include "test-date.h"
+
+#include <kj/test.h>
+
+namespace kj_rs_demo {
+namespace {
+
+KJ_TEST("C++ calls Rust FFI functions") {
+  // Test C++ calling Rust functions directly via FFI
+
+  // Test return functions - C++ calls Rust, Rust returns KjDate
+  auto rust_epoch = r_return_date_epoch();
+  KJ_EXPECT(rust_epoch == kj::UNIX_EPOCH);
+
+  auto rust_specific = r_return_date_specific();
+  auto expected_specific = kj::UNIX_EPOCH + (5000000000LL * kj::NANOSECONDS);  // 5 seconds
+  KJ_EXPECT(rust_specific == expected_specific);
+
+  int64_t test_nanos = 5000000000LL;
+  auto rust_from_nanos = r_return_date_from_nanos(test_nanos);
+  auto expected_from_nanos = kj::UNIX_EPOCH + (test_nanos * kj::NANOSECONDS);
+  KJ_EXPECT(rust_from_nanos == expected_from_nanos);
+}
+
+KJ_TEST("C++ sends dates to Rust FFI functions") {
+  // Test take functions - C++ passes KjDate to Rust for verification
+
+  auto epoch = kj::UNIX_EPOCH;
+  r_take_date_epoch(epoch);  // Should not throw/assert
+
+  int64_t test_nanos = 7500000000LL;
+  auto test_date = kj::UNIX_EPOCH + (test_nanos * kj::NANOSECONDS);
+  r_take_date_and_verify_nanos(test_date, test_nanos);  // Should not throw/assert
+}
+
+KJ_TEST("C++ and Rust FFI round-trip and verification") {
+  // Test complex interactions between C++ and Rust via FFI
+
+  // Round-trip test: C++ -> Rust -> C++
+  auto original = kj::UNIX_EPOCH + (888999000LL * kj::NANOSECONDS);
+  auto rust_round_tripped = r_roundtrip_date(original);
+  KJ_EXPECT(r_verify_date_equality(original, rust_round_tripped));
+
+  // Verification functions: C++ asks Rust to verify dates
+  auto date1 = kj::UNIX_EPOCH + (1234567890LL * kj::NANOSECONDS);
+  auto date2 = kj::UNIX_EPOCH + (1234567890LL * kj::NANOSECONDS);
+  auto date3 = kj::UNIX_EPOCH + (9876543210LL * kj::NANOSECONDS);
+
+  KJ_EXPECT(r_verify_date_equality(date1, date2));
+  KJ_EXPECT(!r_verify_date_equality(date1, date3));
+
+  // Ordering verification: C++ asks Rust to verify ordering
+  auto earlier = kj::UNIX_EPOCH + (1000000000LL * kj::NANOSECONDS);
+  auto later = kj::UNIX_EPOCH + (2000000000LL * kj::NANOSECONDS);
+  KJ_EXPECT(r_verify_date_ordering(earlier, later));
+  KJ_EXPECT(!r_verify_date_ordering(later, earlier));
+
+  // Extraction test: C++ asks Rust to extract nanoseconds
+  int64_t expected_nanos = 3333333333LL;
+  auto test_date = kj::UNIX_EPOCH + (expected_nanos * kj::NANOSECONDS);
+  int64_t rust_extracted = r_extract_nanoseconds(test_date);
+  KJ_EXPECT(rust_extracted == expected_nanos);
+}
+
+}  // namespace
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/lib.rs
+++ b/kj-rs/tests/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::should_panic_without_expect)]
 #![allow(clippy::missing_panics_doc)]
 
+mod test_date;
 mod test_futures;
 mod test_maybe;
 mod test_own;

--- a/kj-rs/tests/test-date.c++
+++ b/kj-rs/tests/test-date.c++
@@ -1,0 +1,64 @@
+#include "test-date.h"
+
+#include "kj/debug.h"
+#include "kj/exception.h"
+#include "kj/time.h"
+
+#include <chrono>
+
+namespace kj_rs_demo {
+
+kj::Date c_create_date_epoch() {
+  return kj::UNIX_EPOCH;
+}
+
+kj::Date c_create_date_from_nanos(int64_t nanoseconds) {
+  return kj::UNIX_EPOCH + (nanoseconds * kj::NANOSECONDS);
+}
+
+kj::Date c_return_date_epoch() {
+  return kj::UNIX_EPOCH;
+}
+
+kj::Date c_return_date_from_nanos(int64_t nanoseconds) {
+  return kj::UNIX_EPOCH + (nanoseconds * kj::NANOSECONDS);
+}
+
+kj::Date c_return_5_sec_after_epoch() {
+  return kj::UNIX_EPOCH + (5000000000LL * kj::NANOSECONDS);
+}
+
+void c_take_date_epoch(kj::Date date) {
+  KJ_ASSERT(date == kj::UNIX_EPOCH, "Expected Unix epoch date");
+}
+
+void c_take_date_7777777777(kj::Date date) {
+  // Expect 7777777777 nanoseconds after Unix epoch (to match Rust test expectation)
+  kj::Date expected = kj::UNIX_EPOCH + (7777777777LL * kj::NANOSECONDS);
+  KJ_ASSERT(date == expected, "Expected specific date (7777777777 nanoseconds after epoch)");
+}
+
+void c_take_date_and_verify_nanos(kj::Date date, int64_t expected_nanos) {
+  kj::Date expected = kj::UNIX_EPOCH + (expected_nanos * kj::NANOSECONDS);
+  KJ_ASSERT(date == expected, "Date nanoseconds don't match expected value", expected_nanos);
+}
+
+kj::Date c_roundtrip_date(kj::Date date) {
+  return date;
+}
+
+bool c_verify_date_equality(kj::Date date1, kj::Date date2) {
+  return date1 == date2;
+}
+
+bool c_verify_date_ordering(kj::Date earlier, kj::Date later) {
+  return earlier < later;
+}
+
+// Conversion testing functions
+int64_t c_extract_nanoseconds_from_date(kj::Date date) {
+  // Extract nanoseconds since Unix epoch
+  return (date - kj::UNIX_EPOCH) / kj::NANOSECONDS;
+}
+
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test-date.h
+++ b/kj-rs/tests/test-date.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "kj-rs-demo/test_date.rs.h"
+
+#include <kj/common.h>
+#include <kj/time.h>
+
+#include <cstdint>
+
+namespace kj_rs_demo {
+
+// Helper functions to create kj::Date values for testing
+kj::Date c_create_date_epoch();
+kj::Date c_create_date_from_nanos(int64_t nanoseconds);
+kj::Date c_create_date_now();
+
+// Functions to test C++ -> Rust Date passing
+kj::Date c_return_date_epoch();
+kj::Date c_return_date_from_nanos(int64_t nanoseconds);
+kj::Date c_return_5_sec_after_epoch();
+
+// Functions to test Rust -> C++ Date passing
+void c_take_date_epoch(kj::Date date);
+void c_take_date_7777777777(kj::Date date);
+void c_take_date_and_verify_nanos(kj::Date date, int64_t expected_nanos);
+
+// Round-trip testing functions
+kj::Date c_roundtrip_date(kj::Date date);
+bool c_verify_date_equality(kj::Date date1, kj::Date date2);
+bool c_verify_date_ordering(kj::Date earlier, kj::Date later);
+
+// Conversion testing functions
+int64_t c_extract_nanoseconds_from_date(kj::Date date);
+
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test_date.rs
+++ b/kj-rs/tests/test_date.rs
@@ -1,0 +1,228 @@
+use kj_rs::KjDate;
+#[allow(dead_code)]
+#[cxx::bridge(namespace = "kj_rs_demo")]
+mod ffi {
+
+    unsafe extern "C++" {
+        include!("kj-rs-demo/test-date.h");
+
+        fn c_create_date_epoch() -> KjDate;
+        fn c_create_date_from_nanos(nanoseconds: i64) -> KjDate;
+        fn c_return_date_epoch() -> KjDate;
+        fn c_return_date_from_nanos(nanoseconds: i64) -> KjDate;
+        fn c_return_5_sec_after_epoch() -> KjDate;
+        fn c_take_date_epoch(date: KjDate);
+        fn c_take_date_7777777777(date: KjDate);
+        fn c_take_date_and_verify_nanos(date: KjDate, expected_nanos: i64);
+        fn c_roundtrip_date(date: KjDate) -> KjDate;
+        fn c_verify_date_equality(date1: KjDate, date2: KjDate) -> bool;
+        fn c_verify_date_ordering(earlier: KjDate, later: KjDate) -> bool;
+        fn c_extract_nanoseconds_from_date(date: KjDate) -> i64;
+    }
+
+    extern "Rust" {
+        // Rust functions that C++ can call for KjDate testing
+        fn r_return_date_epoch() -> KjDate;
+        fn r_return_date_from_nanos(nanoseconds: i64) -> KjDate;
+        fn r_return_date_specific() -> KjDate;
+        fn r_take_date_epoch(date: KjDate);
+        fn r_take_date_and_verify_nanos(date: KjDate, expected_nanos: i64);
+        fn r_roundtrip_date(date: KjDate) -> KjDate;
+        fn r_verify_date_equality(date1: KjDate, date2: KjDate) -> bool;
+        fn r_verify_date_ordering(earlier: KjDate, later: KjDate) -> bool;
+        fn r_extract_nanoseconds(date: KjDate) -> i64;
+        fn r_create_date_from_seconds(seconds: i64) -> KjDate;
+        fn r_verify_date_sequence(dates: &[KjDate]) -> bool;
+    }
+}
+
+pub fn r_take_date_epoch(date: KjDate) {
+    assert_eq!(date.nanoseconds(), 0, "Expected Unix epoch date");
+}
+
+pub fn r_take_date_and_verify_nanos(date: KjDate, expected_nanos: i64) {
+    assert_eq!(
+        date.nanoseconds(),
+        expected_nanos,
+        "Date nanoseconds don't match expected value: expected {}, got {}",
+        expected_nanos,
+        date.nanoseconds()
+    );
+}
+
+pub fn r_return_date_epoch() -> KjDate {
+    KjDate::unix_epoch()
+}
+
+pub fn r_return_date_from_nanos(nanoseconds: i64) -> KjDate {
+    KjDate::from(nanoseconds)
+}
+
+pub fn r_return_date_specific() -> KjDate {
+    KjDate::from(5_000_000_000i64)
+}
+
+pub fn r_roundtrip_date(date: KjDate) -> KjDate {
+    date
+}
+
+pub fn r_verify_date_equality(date1: KjDate, date2: KjDate) -> bool {
+    date1 == date2
+}
+
+pub fn r_verify_date_ordering(earlier: KjDate, later: KjDate) -> bool {
+    earlier < later
+}
+
+pub fn r_extract_nanoseconds(date: KjDate) -> i64 {
+    i64::from(date)
+}
+
+pub fn r_verify_date_sequence(dates: &[KjDate]) -> bool {
+    if dates.len() < 2 {
+        return true;
+    }
+
+    for i in 0..dates.len() - 1 {
+        if dates[i] >= dates[i + 1] {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn r_create_date_from_seconds(seconds: i64) -> KjDate {
+    KjDate::from(seconds * 1_000_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kjdate_creation() {
+        let epoch = KjDate::unix_epoch();
+        assert_eq!(epoch.nanoseconds(), 0);
+
+        let date = KjDate::from(1_000_000_000i64);
+        assert_eq!(date.nanoseconds(), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_kjdate_ordering() {
+        let earlier = KjDate::from(1000i64);
+        let later = KjDate::from(2000i64);
+
+        assert!(earlier < later);
+        assert!(later > earlier);
+        assert!(earlier != later);
+        assert_eq!(earlier, KjDate::from(1000i64));
+    }
+
+    #[test]
+    fn test_kjdate_default() {
+        let default_date = KjDate::default();
+        assert_eq!(default_date, KjDate::unix_epoch());
+    }
+
+    #[test]
+    fn test_rust_calls_cpp_ffi_functions() {
+        // Test Rust calling C++ functions directly via FFI
+
+        // Test creation functions - Rust calls C++, C++ returns KjDate
+        let cpp_epoch = ffi::c_create_date_epoch();
+        assert_eq!(cpp_epoch.nanoseconds(), 0);
+
+        let cpp_from_nanos = ffi::c_create_date_from_nanos(1_000_000_000);
+        assert_eq!(cpp_from_nanos.nanoseconds(), 1_000_000_000);
+
+        // Test C++ -> Rust passing
+        let cpp_returned_epoch = ffi::c_return_date_epoch();
+        assert_eq!(cpp_returned_epoch.nanoseconds(), 0);
+
+        let cpp_returned_from_nanos = ffi::c_return_date_from_nanos(2_500_000_000);
+        assert_eq!(cpp_returned_from_nanos.nanoseconds(), 2_500_000_000);
+
+        let cpp_returned_specific = ffi::c_return_5_sec_after_epoch();
+        assert_eq!(cpp_returned_specific.nanoseconds(), 5_000_000_000); // 5 seconds
+
+        let test_nanos2 = 5_000_000_000i64;
+        let cpp_return_from_nanos = ffi::c_return_date_from_nanos(test_nanos2);
+        assert_eq!(cpp_return_from_nanos.nanoseconds(), test_nanos2);
+    }
+
+    #[test]
+    fn test_rust_sends_dates_to_cpp_ffi() {
+        // Test take functions - Rust passes KjDate to C++ for verification
+        let test_epoch = KjDate::unix_epoch();
+        ffi::c_take_date_epoch(test_epoch); // Should not panic if correct
+
+        let test_specific = KjDate::from(7_777_777_777i64);
+        ffi::c_take_date_7777777777(test_specific); // Should not panic
+
+        let test_verify = KjDate::from(9_999_999_999i64);
+        ffi::c_take_date_and_verify_nanos(test_verify, 9_999_999_999); // Should not panic
+
+        let test_nanos = 7_500_000_000i64;
+        let test_date = KjDate::from(test_nanos);
+        ffi::c_take_date_and_verify_nanos(test_date, test_nanos); // Should not panic
+    }
+
+    #[test]
+    fn test_rust_cpp_ffi_round_trip_and_verification() {
+        // Test complex interactions between Rust and C++ via FFI
+
+        // Round-trip test: Rust -> C++ -> Rust
+        let original = KjDate::from(777_888_999i64);
+        let cpp_round_tripped = ffi::c_roundtrip_date(original);
+        assert!(ffi::c_verify_date_equality(original, cpp_round_tripped));
+
+        // Verification functions: Rust asks C++ to verify dates
+        let date1 = KjDate::from(1_234_567_890i64);
+        let date2 = KjDate::from(1_234_567_890i64);
+        let date3 = KjDate::from(9_876_543_210i64);
+
+        assert!(ffi::c_verify_date_equality(date1, date2));
+        assert!(!ffi::c_verify_date_equality(date1, date3));
+
+        // Ordering verification: Rust asks C++ to verify ordering
+        let earlier = KjDate::from(1_000_000_000i64);
+        let later = KjDate::from(2_000_000_000i64);
+        assert!(ffi::c_verify_date_ordering(earlier, later));
+        assert!(!ffi::c_verify_date_ordering(later, earlier));
+
+        // Extraction test: Rust asks C++ to extract nanoseconds
+        let expected_nanos = 3_333_333_333i64;
+        let test_date = KjDate::from(expected_nanos);
+        let cpp_extracted = ffi::c_extract_nanoseconds_from_date(test_date);
+        assert_eq!(cpp_extracted, expected_nanos);
+    }
+
+    #[test]
+    fn test_kjdate_system_time_conversion() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        // Test conversion from SystemTime
+        let sys_time = UNIX_EPOCH + std::time::Duration::from_nanos(1_500_000_000);
+        let date = KjDate::from(sys_time);
+        assert_eq!(date.nanoseconds(), 1_500_000_000);
+
+        // Test conversion to SystemTime
+        let date = KjDate::from(2_000_000_000i64);
+        let converted_sys_time = SystemTime::from(date);
+        let expected_sys_time = UNIX_EPOCH + std::time::Duration::from_nanos(2_000_000_000);
+        assert_eq!(converted_sys_time, expected_sys_time);
+
+        // Test round trip conversion
+        let original_time = UNIX_EPOCH + std::time::Duration::from_nanos(3_000_000_000);
+        let date = KjDate::from(original_time);
+        let round_trip_time = SystemTime::from(date);
+        assert_eq!(original_time, round_trip_time);
+    }
+
+    #[test]
+    fn test_kjdate_debug() {
+        let date = KjDate::from(123_456_789i64);
+        assert!(format!("{date:?}").starts_with("KjDate(SystemTime"),);
+    }
+}

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -84,7 +84,7 @@ fn check_type(cx: &mut Check, ty: &Type) {
         Type::Array(array) => check_type_array(cx, array),
         Type::Fn(ty) => check_type_fn(cx, ty),
         Type::SliceRef(ty) => check_type_slice_ref(cx, ty),
-        Type::Str(_) | Type::Void(_) => {}
+        Type::Str(_) | Type::Void(_) | Type::KjDate(_) => {}
         Type::Future(ty) => check_type_future(cx, ty),
     }
 }
@@ -797,6 +797,7 @@ fn is_unsized(cx: &mut Check, ty: &Type) -> bool {
         | Type::Ref(_)
         | Type::Ptr(_)
         | Type::Str(_)
+        | Type::KjDate(_)
         | Type::SliceRef(_) => false,
         Type::Future(_) => false,
     }
@@ -873,6 +874,7 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
         Type::SharedPtr(_) => "shared_ptr".to_owned(),
         Type::WeakPtr(_) => "weak_ptr".to_owned(),
         Type::KjMaybe(_) => "kj::Maybe".to_owned(),
+        Type::KjDate(_) => "kj::Date".to_owned(),
         Type::Ref(_) => "reference".to_owned(),
         Type::Ptr(_) => "raw pointer".to_owned(),
         Type::Str(_) => "&str".to_owned(),

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -61,7 +61,7 @@ impl Hash for Type {
             Type::Fn(t) => t.hash(state),
             Type::SliceRef(t) => t.hash(state),
             Type::Array(t) => t.hash(state),
-            Type::Void(_) => {}
+            Type::Void(_) | Type::KjDate(_) => {}
             Type::Future(t) => t.hash(state),
         }
     }
@@ -85,6 +85,7 @@ impl PartialEq for Type {
             (Type::Fn(lhs), Type::Fn(rhs)) => lhs == rhs,
             (Type::SliceRef(lhs), Type::SliceRef(rhs)) => lhs == rhs,
             (Type::Void(_), Type::Void(_)) => true,
+            (Type::KjDate(_), Type::KjDate(_)) => true,
             (Type::Future(lhs), Type::Future(rhs)) => lhs == rhs,
             (_, _) => false,
         }

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -27,6 +27,7 @@ impl<'a> Types<'a> {
             | Type::Str(_)
             | Type::Fn(_)
             | Type::Void(_)
+            | Type::KjDate(_)
             | Type::SliceRef(_) => Definite(true),
             Type::UniquePtr(_) | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) => {
                 Definite(false)

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -304,6 +304,7 @@ pub enum Type {
     Fn(Box<Signature>),
     Void(Span),
     KjMaybe(Box<Ty1>),
+    KjDate(Span),
     SliceRef(Box<SliceRef>),
     Array(Box<Array>),
     Future(Box<Future>),

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -32,7 +32,12 @@ impl<'a> Types<'a> {
             | Type::WeakPtr(_)
             | Type::CxxVector(_)
             | Type::Void(_) => false,
-            Type::Ref(_) | Type::Str(_) | Type::Fn(_) | Type::SliceRef(_) | Type::Ptr(_) => true,
+            Type::Ref(_)
+            | Type::Str(_)
+            | Type::Fn(_)
+            | Type::SliceRef(_)
+            | Type::Ptr(_)
+            | Type::KjDate(_) => true,
             Type::KjMaybe(ty) => self.is_guaranteed_pod(&ty.inner),
             Type::Array(array) => self.is_guaranteed_pod(&array.inner),
             Type::Future(_) => false,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -39,6 +39,7 @@ impl ToTokens for Type {
             Type::Array(a) => a.to_tokens(tokens),
             Type::Fn(f) => f.to_tokens(tokens),
             Type::Void(span) => tokens.extend(quote_spanned!(*span=> ())),
+            Type::KjDate(span) => tokens.extend(quote_spanned!(*span=> ::kj_rs::KjDate)),
             Type::SliceRef(r) => r.to_tokens(tokens),
             Type::Future(f) => f.to_tokens(tokens),
         }

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -11,7 +11,7 @@ where
     V: Visit<'a> + ?Sized,
 {
     match ty {
-        Type::Ident(_) | Type::Str(_) | Type::Void(_) => {}
+        Type::Ident(_) | Type::Str(_) | Type::Void(_) | Type::KjDate(_) => {}
         Type::RustBox(ty)
         | Type::UniquePtr(ty)
         | Type::KjOwn(ty)


### PR DESCRIPTION
represented as `KjDate` object on rust side. Allows passing in and out in functions.