### PR TITLE
add ::rust::String::latin1 constructor

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -135,6 +135,8 @@ public:
   static String lossy(const char16_t *) noexcept;
   static String lossy(const char16_t *, std::size_t) noexcept;
 
+  static String latin1(const char*, std::size_t) noexcept;
+
   String &operator=(const String &) & noexcept;
   String &operator=(String &&) & noexcept;
 
@@ -177,6 +179,8 @@ private:
   struct lossy_t;
   String(lossy_t, const char *, std::size_t) noexcept;
   String(lossy_t, const char16_t *, std::size_t) noexcept;
+  struct latin1_t;
+  String(latin1_t, const char *, std::size_t) noexcept;
   friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
 
   // Size and alignment statically verified by rust_string.rs.

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -41,6 +41,8 @@ void cxxbridge1$cxx_string$push(std::string &s, const std::uint8_t *ptr,
 void cxxbridge1$string$new(rust::String *self) noexcept;
 void cxxbridge1$string$clone(rust::String *self,
                              const rust::String &other) noexcept;
+void cxxbridge1$string$from_latin1(rust::String *self, const char *ptr,
+                                   std::size_t len) noexcept;
 bool cxxbridge1$string$from_utf8(rust::String *self, const char *ptr,
                                  std::size_t len) noexcept;
 void cxxbridge1$string$from_utf8_lossy(rust::String *self, const char *ptr,
@@ -193,6 +195,19 @@ String String::lossy(const char16_t *s, std::size_t len) noexcept {
   assert(s != nullptr || len == 0);
   assert(is_aligned<char16_t>(s));
   return String(lossy_t{}, s, len);
+}
+
+struct String::latin1_t {};
+
+String::String(latin1_t, const char *s, std::size_t len) noexcept {
+  cxxbridge1$string$from_latin1(
+      this, s == nullptr && len == 0 ? reinterpret_cast<const char *>(1) : s,
+      len);
+}
+
+String String::latin1(const char *s, std::size_t len) noexcept {
+  assert(s != nullptr || len == 0);
+  return String(latin1_t{}, s, len);
 }
 
 String &String::operator=(const String &other) & noexcept {

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -19,6 +19,18 @@ unsafe extern "C" fn string_clone(this: &mut MaybeUninit<String>, other: &String
     unsafe { ptr::write(this, clone) }
 }
 
+#[export_name = "cxxbridge1$string$from_latin1"]
+unsafe extern "C" fn string_from_latin1(
+    this: &mut MaybeUninit<String>,
+    ptr: *const u8,
+    len: usize,
+) {
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    let this = this.as_mut_ptr();
+    let owned = slice.iter().map(|&c| c as char).collect();
+    unsafe { ptr::write(this, owned) }
+}
+
 #[export_name = "cxxbridge1$string$from_utf8"]
 unsafe extern "C" fn string_from_utf8(
     this: &mut MaybeUninit<String>,

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -987,6 +987,18 @@ extern "C" const char *cxx_run_test() noexcept {
   rust::String bad_utf16_rstring = rust::String::lossy(bad_utf16_literal);
   ASSERT(bad_utf8_rstring == bad_utf16_rstring);
 
+  const char *ascii_literal = "42";
+  const char *latin1_literal = "\xff";
+  rust::String ascii =
+      rust::String::latin1(ascii_literal, strlen(ascii_literal));
+  rust::String latin1 =
+      rust::String::latin1(latin1_literal, strlen(latin1_literal));
+  KJ_ASSERT(kj::arrayPtr(ascii.c_str(), ascii.length()) == "42"_kjb);
+  // \xff is a valid latin1 character but needs to converted into multi-byte utf8.
+  char expected[] = {static_cast<char>(195), static_cast<char>(191)};
+  KJ_ASSERT(kj::arrayPtr(latin1.c_str(), latin1.length()) ==
+            kj::arrayPtr(expected));
+
   // Test Slice<T> explicit constructor from container
   {
     std::vector<int> cpp_vec{1, 2, 3};


### PR DESCRIPTION
Adds a constructor to avoid an unnecessary copy for latin1 characters (provided by v8).