### PR TITLE
[workerd-cxx] marking kj::Maybe as a non-pod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,13 +34,18 @@ build:clippy --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:clippy --output_groups=+rustfmt_checks
 build:clippy --@rules_rust//:extra_rustc_flag=-Dwarnings
 
+build:max-debug-info -c dbg
+build:max-debug-info --copt="-O0"
+build:max-debug-info --copt="-g3" --copt="-fstandalone-debug" --copt="-fno-limit-debug-info" --strip=never
+build:max-debug-info --copt="-fno-optimize-sibling-calls"
+build:max-debug-info --copt="-fno-omit-frame-pointer" --copt="-mno-omit-leaf-frame-pointer"
+build:max-debug-info --@rules_rust//:extra_rustc_flag=-Cdebuginfo=2
+build:max-debug-info --@rules_rust//:extra_rustc_flag=-Cforce-frame-pointers=yes
+
 ## Sanitizers
 
+build:sanitizer-common --config=max-debug-info
 build:sanitizer-common --copt="-fsanitize-link-c++-runtime" --linkopt="-fsanitize-link-c++-runtime"
-build:sanitizer-common --copt="-Og"
-build:sanitizer-common --copt="-g" --strip=never
-build:sanitizer-common --copt="-fno-optimize-sibling-calls"
-build:sanitizer-common --copt="-fno-omit-frame-pointer" --copt="-mno-omit-leaf-frame-pointer"
 
 # Address sanitizer (https://github.com/google/sanitizers/wiki/AddressSanitizer)
 build:asan --config=sanitizer-common

--- a/kj-rs/tests/BUILD.bazel
+++ b/kj-rs/tests/BUILD.bazel
@@ -170,3 +170,21 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "maybe-test",
+    size = "medium",
+    srcs = [
+        "maybe-test.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    deps = [
+        ":bridge",
+        ":tests",
+        "//third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/kj-rs/tests/lib.rs
+++ b/kj-rs/tests/lib.rs
@@ -298,6 +298,19 @@ mod ffi {
         async unsafe fn lifetime_arg_void<'a>(buf: &'a [u8]);
         async unsafe fn lifetime_arg_result<'a>(buf: &'a [u8]) -> Result<()>;
     }
+
+    struct StructWithMaybe {
+        b: bool,
+        u: KjMaybe<u64>,
+    }
+
+    extern "Rust" {
+        async unsafe fn pass_struct_with_maybe(x: StructWithMaybe) -> Result<()>;
+    }
+}
+
+async fn pass_struct_with_maybe(_x: ffi::StructWithMaybe) -> Result<()> {
+    Ok(())
 }
 
 unsafe impl Send for ffi::OpaqueAtomicRefcountedClass {}

--- a/kj-rs/tests/maybe-test.c++
+++ b/kj-rs/tests/maybe-test.c++
@@ -1,0 +1,16 @@
+#include "kj-rs/tests/lib.rs.h"
+
+#include <kj/test.h>
+
+namespace kj_rs_demo {
+namespace {
+
+KJ_TEST("struct with maybe") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  auto promise = pass_struct_with_maybe(::kj_rs_demo::StructWithMaybe());
+}
+
+}  // namespace
+}  // namespace kj_rs_demo

--- a/kj-rs/tests/test-maybe.h
+++ b/kj-rs/tests/test-maybe.h
@@ -1,11 +1,15 @@
 #pragma once
 
-#include "kj-rs-demo/lib.rs.h"
-#include "kj/common.h"
+#include "kj-rs/tests/test-own.h"
+
+#include <kj/common.h>
 
 #include <cstdint>
 
 namespace kj_rs_demo {
+
+struct Shared;
+class OpaqueCxxClass;
 
 kj::Maybe<Shared> return_maybe_shared_some();
 kj::Maybe<Shared> return_maybe_shared_none();

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -38,7 +38,9 @@ impl<'a> Types<'a> {
             | Type::SliceRef(_)
             | Type::Ptr(_)
             | Type::KjDate(_) => true,
-            Type::KjMaybe(ty) => self.is_guaranteed_pod(&ty.inner),
+            // kj::Maybe can't be considered to be a POD:
+            // <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial>
+            Type::KjMaybe(_) => false,
             Type::Array(array) => self.is_guaranteed_pod(&array.inner),
             Type::Future(_) => false,
         }


### PR DESCRIPTION
kj::Maybe presence in the struct makes it not a POD from ABI perspective. Mark it as such, otherwise C++ side passes a pointer, but Rust side expects a value.