### PR TITLE
[workerd-cxx] eager async function calling

### DIFF
--- a/kj-rs/lib.rs
+++ b/kj-rs/lib.rs
@@ -5,6 +5,7 @@ pub use crate::ffi::KjWaker;
 pub use awaiter::PromiseAwaiter;
 pub use date::KjDate;
 pub use future::FuturePollStatus;
+pub use future::map_err;
 pub use maybe::repr::KjMaybe;
 pub use own::repr::KjOwn;
 pub use promise::KjPromise;

--- a/kj-rs/tests/awaitables-cc-test.c++
+++ b/kj-rs/tests/awaitables-cc-test.c++
@@ -6,6 +6,7 @@
 #include "kj-rs/future.h"
 #include "kj-rs/tests/lib.rs.h"
 #include "kj-rs/waker.h"
+#include <sys/types.h>
 
 #include <kj/test.h>
 
@@ -167,6 +168,17 @@ KJ_TEST("C++ can receive asynchronous wakes after poll()") {
   KJ_EXPECT(!promise.poll(waitScope));
   // But later it is.
   promise.wait(waitScope);
+}
+
+KJ_TEST("Work before poll") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  uint64_t val = 0;
+  // It should be possible for rust function to do work before returning the future
+  // even if we don't poll or cancel it.
+  auto promise = work_before_poll(val);
+  KJ_EXPECT(val == 42);
 }
 
 // TODO(now): More test cases.

--- a/kj-rs/tests/lib.rs
+++ b/kj-rs/tests/lib.rs
@@ -290,6 +290,8 @@ mod ffi {
         async fn new_awaiting_future_i32() -> Result<()>;
         async fn new_ready_future_i32(value: i32) -> Result<i32>;
         async fn new_pass_through_feature_shared() -> Shared;
+
+        async unsafe fn work_before_poll<'a>(target: &'a mut u64) -> Result<()>;
     }
 
     // these are used to check compilation only
@@ -346,6 +348,14 @@ pub async fn new_pass_through_feature_shared() -> ffi::Shared {
 
 async fn new_ready_future_shared_type() -> ffi::Shared {
     ffi::Shared { i: 42 }
+}
+
+fn work_before_poll(target: &mut u64) -> impl Future<Output = Result<()>> {
+    *target = 42;
+
+    async move {
+        unimplemented!("not expected to be polled");
+    }
 }
 
 #[cfg(test)]

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1300,7 +1300,7 @@ fn expand_rust_function_shim_super(
 
     let mut body = if let Some(Type::Future(fut)) = &sig.ret {
         if fut.throws_tokens.is_some() {
-            quote_spanned!(span=> Box::pin(async move {#call(#(#vars,)*).await.map_err(|e| ::cxx::IntoKjException::into_kj_exception(e, ::cxx::core::file!(), ::cxx::core::line!()))}))
+            quote_spanned!(span=> Box::pin(::kj_rs::map_err(#call(#(#vars,)*), ::cxx::core::file!(), ::cxx::core::line!())))
         } else {
             quote_spanned!(span=> Box::pin(#call(#(#vars,)*)))
         }


### PR DESCRIPTION
We wrapped real async function call into additional async block which didn't make it possible to do work before returning a future.

The goal was to call map_err, implement a custom Future type instead.