### PR TITLE
enable kj::Own in shared structs

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -760,6 +760,10 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
     let fn_token = efn.sig.fn_token;
     let ident = &efn.name.rust;
     let generics = &efn.generics;
+    let missing_panics_doc = match &efn.ret {
+        Some(Type::KjOwn(_)) => quote!(#[allow(clippy::missing_panics_doc)]),
+        _ => quote!(),
+    };
     let arg_list = quote_spanned!(efn.sig.paren_token.span=> (#(#all_args,)*));
     let fn_body = quote_spanned!(span=> {
         #UnsafeExtern extern "C" {
@@ -773,6 +777,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
             quote! {
                 #doc
                 #attrs
+                #missing_panics_doc
                 #visibility #unsafety #fn_token #ident #generics #arg_list #ret #fn_body
             }
         }
@@ -803,6 +808,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                 impl #generics #receiver_ident #receiver_generics {
                     #doc
                     #attrs
+                    #missing_panics_doc
                     #visibility #unsafety #fn_token #ident #arg_list #ret #fn_body
                 }
             }

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -29,14 +29,16 @@ impl<'a> Types<'a> {
             | Type::Void(_)
             | Type::KjDate(_)
             | Type::SliceRef(_) => Definite(true),
-            Type::UniquePtr(_) | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) => {
-                Definite(false)
-            }
+            Type::UniquePtr(_)
+            | Type::KjOwn(_)
+            | Type::SharedPtr(_)
+            | Type::WeakPtr(_)
+            | Type::CxxVector(_) => Definite(false),
             Type::Ref(ty) => self.determine_improper_ctype(&ty.inner),
             Type::Ptr(ty) => self.determine_improper_ctype(&ty.inner),
             Type::Array(ty) => self.determine_improper_ctype(&ty.inner),
             Type::KjMaybe(ty) => self.determine_improper_ctype(&ty.inner),
-            Type::Future(_) | Type::KjOwn(_) | Type::KjRc(_) | Type::KjArc(_) => {
+            Type::Future(_) | Type::KjRc(_) | Type::KjArc(_) => {
                 todo!("file a workerd-cxx ticket")
             }
         }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -81,6 +81,7 @@ rust_cxx_bridge(
         ":jsg-mock",
         ":module",
         "//:core",
+        "//kj-rs:kj-rs-lib",
     ],
 )
 

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -21,6 +21,28 @@ const BRIDGE1: &str = r"
     }
 ";
 
+const BRIDGE2: &str = r#"
+    #[cxx::bridge]
+    mod ffi {
+        struct Holder {
+            own: KjOwn<Thing>,
+        }
+
+        struct MultiHolder {
+            first: KjOwn<Thing>,
+            second: KjOwn<Thing>,
+        }
+
+        unsafe extern "C++" {
+            type Thing;
+        }
+
+        extern "Rust" {
+            fn pass_holder(holder: Holder) -> Holder;
+        }
+    }
+"#;
+
 #[test]
 fn test_extern_c_function() {
     let opt = Opt::default();
@@ -52,4 +74,18 @@ fn test_jsg_struct_derive() {
     let output = str::from_utf8(&generated.header).unwrap();
     assert!(output.contains("JSG_STRUCT(field1, field2);"));
     assert!(output.contains("jsg.h"));
+}
+
+#[test]
+fn test_kj_own_in_shared_struct() {
+    let opt = Opt::default();
+    let source = BRIDGE2.parse().unwrap();
+    let generated = generate_header_and_cc(source, &opt).unwrap();
+    let header = str::from_utf8(&generated.header).unwrap();
+    let implementation = str::from_utf8(&generated.implementation).unwrap();
+    assert!(header.contains("::kj::Own<::Thing> own;"));
+    assert!(header.contains("::kj::Own<::Thing> first;"));
+    assert!(header.contains("::kj::Own<::Thing> second;"));
+    assert!(header.contains("kj-rs/kj-rs.h"));
+    assert!(implementation.contains("::rust::ManuallyDrop<::Holder> holder$(::std::move(holder));"));
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -21,6 +21,10 @@ use core::fmt;
 use cxx::{
     type_id, CxxString, CxxVector, ExternType, KjError, KjExceptionType, SharedPtr, UniquePtr,
 };
+// The bridge parser accepts the unqualified smart-pointer name, while expansion
+// fully qualifies the emitted Rust field type.
+#[allow(unused_imports)]
+use kj_rs::KjOwn;
 use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::os::raw::c_char;
@@ -43,6 +47,15 @@ pub mod ffi {
         critical: u8,
         field: String,
         value: String,
+    }
+
+    struct SharedWithKjOwn {
+        own: KjOwn<C>,
+    }
+
+    struct SharedWithMultipleKjOwns {
+        first: KjOwn<C>,
+        second: KjOwn<C>,
     }
 
     #[derive(Debug, Hash, PartialOrd, Ord)]
@@ -141,6 +154,24 @@ pub mod ffi {
         fn c_return_nested_ns_enum(n: u16) -> ABEnum;
         fn c_return_const_ptr(n: usize) -> *const C;
         fn c_return_mut_ptr(n: usize) -> *mut C;
+        fn c_return_kj_own(n: usize) -> KjOwn<C>;
+        fn c_sizeof_shared_with_kj_own() -> usize;
+        fn c_alignof_shared_with_kj_own() -> usize;
+        fn c_sizeof_shared_with_multiple_kj_owns() -> usize;
+        fn c_alignof_shared_with_multiple_kj_owns() -> usize;
+        fn c_return_shared_with_kj_own(n: usize) -> SharedWithKjOwn;
+        fn c_return_shared_with_multiple_kj_owns(
+            first: usize,
+            second: usize,
+        ) -> SharedWithMultipleKjOwns;
+        fn c_take_shared_with_kj_own_by_value(shared: SharedWithKjOwn) -> usize;
+        fn c_take_shared_with_kj_own_by_ref(shared: &SharedWithKjOwn) -> usize;
+        fn c_take_shared_with_multiple_kj_owns_by_value(shared: SharedWithMultipleKjOwns) -> usize;
+        fn c_take_shared_with_multiple_kj_owns_by_ref(shared: &SharedWithMultipleKjOwns) -> usize;
+        fn c_roundtrip_shared_with_kj_own(shared: SharedWithKjOwn) -> SharedWithKjOwn;
+        fn c_roundtrip_shared_with_multiple_kj_owns(
+            shared: SharedWithMultipleKjOwns,
+        ) -> SharedWithMultipleKjOwns;
 
         fn c_take_primitive(n: usize);
         fn c_take_shared(shared: Shared);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -25,6 +25,11 @@ namespace tests {
 
 static constexpr char SLICE_DATA[] = "2020";
 
+static_assert(sizeof(SharedWithKjOwn) == sizeof(kj::Own<C>));
+static_assert(alignof(SharedWithKjOwn) == alignof(kj::Own<C>));
+static_assert(sizeof(SharedWithMultipleKjOwns) == 2 * sizeof(kj::Own<C>));
+static_assert(alignof(SharedWithMultipleKjOwns) == alignof(kj::Own<C>));
+
 C::C(size_t n) : n(n) {}
 
 size_t C::get() const { return this->n; }
@@ -228,6 +233,59 @@ Enum c_return_enum(uint16_t n) {
 const C *c_return_const_ptr(size_t c) { return new C(c); }
 
 C *c_return_mut_ptr(size_t c) { return new C(c); }
+
+kj::Own<C> c_return_kj_own(size_t n) { return kj::heap<C>(n); }
+
+size_t c_sizeof_shared_with_kj_own() { return sizeof(SharedWithKjOwn); }
+
+size_t c_alignof_shared_with_kj_own() { return alignof(SharedWithKjOwn); }
+
+size_t c_sizeof_shared_with_multiple_kj_owns() {
+  return sizeof(SharedWithMultipleKjOwns);
+}
+
+size_t c_alignof_shared_with_multiple_kj_owns() {
+  return alignof(SharedWithMultipleKjOwns);
+}
+
+SharedWithKjOwn c_return_shared_with_kj_own(size_t n) {
+  return SharedWithKjOwn{kj::heap<C>(n)};
+}
+
+SharedWithMultipleKjOwns c_return_shared_with_multiple_kj_owns(size_t first,
+                                                               size_t second) {
+  return SharedWithMultipleKjOwns{kj::heap<C>(first), kj::heap<C>(second)};
+}
+
+size_t c_take_shared_with_kj_own_by_value(SharedWithKjOwn shared) {
+  return shared.own->get();
+}
+
+size_t c_take_shared_with_kj_own_by_ref(const SharedWithKjOwn &shared) {
+  return shared.own->get();
+}
+
+size_t
+c_take_shared_with_multiple_kj_owns_by_value(SharedWithMultipleKjOwns shared) {
+  return shared.first->get() + shared.second->get();
+}
+
+size_t c_take_shared_with_multiple_kj_owns_by_ref(
+    const SharedWithMultipleKjOwns &shared) {
+  return shared.first->get() + shared.second->get();
+}
+
+SharedWithKjOwn c_roundtrip_shared_with_kj_own(SharedWithKjOwn shared) {
+  shared.own->set(shared.own->get() + 1);
+  return shared;
+}
+
+SharedWithMultipleKjOwns
+c_roundtrip_shared_with_multiple_kj_owns(SharedWithMultipleKjOwns shared) {
+  shared.first->set(shared.first->get() + 10);
+  shared.second->set(shared.second->get() + 20);
+  return shared;
+}
 
 Borrow::Borrow(const std::string &s) : s(s) {}
 

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "rust/cxx.h"
 
+#include <kj/memory.h>
+
 #include <memory>
 #include <string>
 
@@ -38,6 +40,8 @@ namespace tests {
 struct R;
 struct Shared;
 struct SharedString;
+struct SharedWithKjOwn;
+struct SharedWithMultipleKjOwns;
 enum class Enum : uint16_t;
 
 class C {
@@ -126,6 +130,23 @@ Enum c_return_enum(uint16_t n);
 std::unique_ptr<Borrow> c_return_borrow(const std::string &s);
 const C *c_return_const_ptr(size_t n);
 C *c_return_mut_ptr(size_t n);
+kj::Own<C> c_return_kj_own(size_t n);
+size_t c_sizeof_shared_with_kj_own();
+size_t c_alignof_shared_with_kj_own();
+size_t c_sizeof_shared_with_multiple_kj_owns();
+size_t c_alignof_shared_with_multiple_kj_owns();
+SharedWithKjOwn c_return_shared_with_kj_own(size_t n);
+SharedWithMultipleKjOwns c_return_shared_with_multiple_kj_owns(size_t first,
+                                                               size_t second);
+size_t c_take_shared_with_kj_own_by_value(SharedWithKjOwn shared);
+size_t c_take_shared_with_kj_own_by_ref(const SharedWithKjOwn &shared);
+size_t
+c_take_shared_with_multiple_kj_owns_by_value(SharedWithMultipleKjOwns shared);
+size_t c_take_shared_with_multiple_kj_owns_by_ref(
+    const SharedWithMultipleKjOwns &shared);
+SharedWithKjOwn c_roundtrip_shared_with_kj_own(SharedWithKjOwn shared);
+SharedWithMultipleKjOwns
+c_roundtrip_shared_with_multiple_kj_owns(SharedWithMultipleKjOwns shared);
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,6 +13,7 @@ use cxx_test_suite::module::ffi2;
 use cxx_test_suite::{cast, ffi, R};
 use std::cell::Cell;
 use std::ffi::CStr;
+use std::mem::{align_of, size_of};
 use std::panic::{self, RefUnwindSafe, UnwindSafe};
 
 thread_local! {
@@ -99,6 +100,58 @@ fn test_c_return() {
         enm @ ffi::ABEnum::ABAVal => assert_eq!(0, enm.repr),
         _ => assert!(false),
     }
+}
+
+#[test]
+fn test_kj_own_shared_struct_abi() {
+    assert_eq!(
+        size_of::<ffi::SharedWithKjOwn>(),
+        ffi::c_sizeof_shared_with_kj_own()
+    );
+    assert_eq!(
+        align_of::<ffi::SharedWithKjOwn>(),
+        ffi::c_alignof_shared_with_kj_own()
+    );
+    assert_eq!(
+        size_of::<ffi::SharedWithMultipleKjOwns>(),
+        ffi::c_sizeof_shared_with_multiple_kj_owns()
+    );
+    assert_eq!(
+        align_of::<ffi::SharedWithMultipleKjOwns>(),
+        ffi::c_alignof_shared_with_multiple_kj_owns()
+    );
+}
+
+#[test]
+fn test_kj_own_shared_struct_roundtrip() {
+    let shared = ffi::c_return_shared_with_kj_own(3030);
+    assert_eq!(3030, shared.own.get());
+    assert_eq!(3030, ffi::c_take_shared_with_kj_own_by_ref(&shared));
+    assert_eq!(3030, ffi::c_take_shared_with_kj_own_by_value(shared));
+
+    let shared = ffi::c_return_shared_with_multiple_kj_owns(1010, 2020);
+    assert_eq!(
+        3030,
+        ffi::c_take_shared_with_multiple_kj_owns_by_ref(&shared)
+    );
+    assert_eq!(
+        3030,
+        ffi::c_take_shared_with_multiple_kj_owns_by_value(shared)
+    );
+
+    let shared = ffi::SharedWithKjOwn {
+        own: ffi::c_return_kj_own(2020),
+    };
+    let shared = ffi::c_roundtrip_shared_with_kj_own(shared);
+    assert_eq!(2021, shared.own.get());
+
+    let shared = ffi::SharedWithMultipleKjOwns {
+        first: ffi::c_return_kj_own(1010),
+        second: ffi::c_return_kj_own(2020),
+    };
+    let shared = ffi::c_roundtrip_shared_with_multiple_kj_owns(shared);
+    assert_eq!(1020, shared.first.get());
+    assert_eq!(2040, shared.second.get());
 }
 
 #[test]


### PR DESCRIPTION
Since it has same memory layout it works out of the box. Simply adding bunch of tests to verify.