### PR TITLE
enable kj::Rc in shared structs

### DIFF
--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -31,6 +31,7 @@ impl<'a> Types<'a> {
             | Type::SliceRef(_) => Definite(true),
             Type::UniquePtr(_)
             | Type::KjOwn(_)
+            | Type::KjRc(_)
             | Type::SharedPtr(_)
             | Type::WeakPtr(_)
             | Type::CxxVector(_) => Definite(false),
@@ -38,7 +39,7 @@ impl<'a> Types<'a> {
             Type::Ptr(ty) => self.determine_improper_ctype(&ty.inner),
             Type::Array(ty) => self.determine_improper_ctype(&ty.inner),
             Type::KjMaybe(ty) => self.determine_improper_ctype(&ty.inner),
-            Type::Future(_) | Type::KjRc(_) | Type::KjArc(_) => {
+            Type::Future(_) | Type::KjArc(_) => {
                 todo!("file a workerd-cxx ticket")
             }
         }

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -43,6 +43,28 @@ const BRIDGE2: &str = r#"
     }
 "#;
 
+const BRIDGE3: &str = r#"
+    #[cxx::bridge]
+    mod ffi {
+        struct Holder {
+            rc: KjRc<Thing>,
+        }
+
+        struct MultiHolder {
+            first: KjRc<Thing>,
+            second: KjRc<Thing>,
+        }
+
+        unsafe extern "C++" {
+            type Thing;
+        }
+
+        extern "Rust" {
+            fn pass_holder(holder: Holder) -> Holder;
+        }
+    }
+"#;
+
 #[test]
 fn test_extern_c_function() {
     let opt = Opt::default();
@@ -86,6 +108,20 @@ fn test_kj_own_in_shared_struct() {
     assert!(header.contains("::kj::Own<::Thing> own;"));
     assert!(header.contains("::kj::Own<::Thing> first;"));
     assert!(header.contains("::kj::Own<::Thing> second;"));
+    assert!(header.contains("kj-rs/kj-rs.h"));
+    assert!(implementation.contains("::rust::ManuallyDrop<::Holder> holder$(::std::move(holder));"));
+}
+
+#[test]
+fn test_kj_rc_in_shared_struct() {
+    let opt = Opt::default();
+    let source = BRIDGE3.parse().unwrap();
+    let generated = generate_header_and_cc(source, &opt).unwrap();
+    let header = str::from_utf8(&generated.header).unwrap();
+    let implementation = str::from_utf8(&generated.implementation).unwrap();
+    assert!(header.contains("::kj::Rc<::Thing> rc;"));
+    assert!(header.contains("::kj::Rc<::Thing> first;"));
+    assert!(header.contains("::kj::Rc<::Thing> second;"));
     assert!(header.contains("kj-rs/kj-rs.h"));
     assert!(implementation.contains("::rust::ManuallyDrop<::Holder> holder$(::std::move(holder));"));
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -24,7 +24,7 @@ use cxx::{
 // The bridge parser accepts the unqualified smart-pointer name, while expansion
 // fully qualifies the emitted Rust field type.
 #[allow(unused_imports)]
-use kj_rs::KjOwn;
+use kj_rs::{KjOwn, KjRc};
 use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::os::raw::c_char;
@@ -56,6 +56,15 @@ pub mod ffi {
     struct SharedWithMultipleKjOwns {
         first: KjOwn<C>,
         second: KjOwn<C>,
+    }
+
+    struct SharedWithKjRc {
+        rc: KjRc<RcC>,
+    }
+
+    struct SharedWithMultipleKjRcs {
+        first: KjRc<RcC>,
+        second: KjRc<RcC>,
     }
 
     #[derive(Debug, Hash, PartialOrd, Ord)]
@@ -172,6 +181,24 @@ pub mod ffi {
         fn c_roundtrip_shared_with_multiple_kj_owns(
             shared: SharedWithMultipleKjOwns,
         ) -> SharedWithMultipleKjOwns;
+        fn c_return_kj_rc(n: usize) -> KjRc<RcC>;
+        fn c_sizeof_shared_with_kj_rc() -> usize;
+        fn c_alignof_shared_with_kj_rc() -> usize;
+        fn c_sizeof_shared_with_multiple_kj_rcs() -> usize;
+        fn c_alignof_shared_with_multiple_kj_rcs() -> usize;
+        fn c_return_shared_with_kj_rc(n: usize) -> SharedWithKjRc;
+        fn c_return_shared_with_multiple_kj_rcs(
+            first: usize,
+            second: usize,
+        ) -> SharedWithMultipleKjRcs;
+        fn c_take_shared_with_kj_rc_by_value(shared: SharedWithKjRc) -> usize;
+        fn c_take_shared_with_kj_rc_by_ref(shared: &SharedWithKjRc) -> usize;
+        fn c_take_shared_with_multiple_kj_rcs_by_value(shared: SharedWithMultipleKjRcs) -> usize;
+        fn c_take_shared_with_multiple_kj_rcs_by_ref(shared: &SharedWithMultipleKjRcs) -> usize;
+        fn c_roundtrip_shared_with_kj_rc(shared: SharedWithKjRc) -> SharedWithKjRc;
+        fn c_roundtrip_shared_with_multiple_kj_rcs(
+            shared: SharedWithMultipleKjRcs,
+        ) -> SharedWithMultipleKjRcs;
 
         fn c_take_primitive(n: usize);
         fn c_take_shared(shared: Shared);
@@ -267,6 +294,12 @@ pub mod ffi {
 
         #[namespace = "other"]
         fn ns_c_take_ns_shared(shared: AShared);
+    }
+
+    unsafe extern "C++" {
+        include!("tests/ffi/tests.h");
+
+        type RcC;
     }
 
     extern "C++" {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -29,6 +29,10 @@ static_assert(sizeof(SharedWithKjOwn) == sizeof(kj::Own<C>));
 static_assert(alignof(SharedWithKjOwn) == alignof(kj::Own<C>));
 static_assert(sizeof(SharedWithMultipleKjOwns) == 2 * sizeof(kj::Own<C>));
 static_assert(alignof(SharedWithMultipleKjOwns) == alignof(kj::Own<C>));
+static_assert(sizeof(SharedWithKjRc) == sizeof(kj::Rc<RcC>));
+static_assert(alignof(SharedWithKjRc) == alignof(kj::Rc<RcC>));
+static_assert(sizeof(SharedWithMultipleKjRcs) == 2 * sizeof(kj::Rc<RcC>));
+static_assert(alignof(SharedWithMultipleKjRcs) == alignof(kj::Rc<RcC>));
 
 C::C(size_t n) : n(n) {}
 
@@ -48,6 +52,12 @@ size_t C::set(size_t n) {
 size_t C::set_succeed(size_t n) { return this->set(n); }
 
 size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
+
+RcC::RcC(size_t n) : n(n) {}
+
+size_t RcC::get() const { return this->n; }
+
+void RcC::set(size_t n) { this->n = n; }
 
 size_t Shared::c_method_on_shared() const noexcept { return 2021; }
 
@@ -282,6 +292,59 @@ SharedWithKjOwn c_roundtrip_shared_with_kj_own(SharedWithKjOwn shared) {
 
 SharedWithMultipleKjOwns
 c_roundtrip_shared_with_multiple_kj_owns(SharedWithMultipleKjOwns shared) {
+  shared.first->set(shared.first->get() + 10);
+  shared.second->set(shared.second->get() + 20);
+  return shared;
+}
+
+kj::Rc<RcC> c_return_kj_rc(size_t n) { return kj::rc<RcC>(n); }
+
+size_t c_sizeof_shared_with_kj_rc() { return sizeof(SharedWithKjRc); }
+
+size_t c_alignof_shared_with_kj_rc() { return alignof(SharedWithKjRc); }
+
+size_t c_sizeof_shared_with_multiple_kj_rcs() {
+  return sizeof(SharedWithMultipleKjRcs);
+}
+
+size_t c_alignof_shared_with_multiple_kj_rcs() {
+  return alignof(SharedWithMultipleKjRcs);
+}
+
+SharedWithKjRc c_return_shared_with_kj_rc(size_t n) {
+  return SharedWithKjRc{kj::rc<RcC>(n)};
+}
+
+SharedWithMultipleKjRcs c_return_shared_with_multiple_kj_rcs(size_t first,
+                                                             size_t second) {
+  return SharedWithMultipleKjRcs{kj::rc<RcC>(first), kj::rc<RcC>(second)};
+}
+
+size_t c_take_shared_with_kj_rc_by_value(SharedWithKjRc shared) {
+  return shared.rc->get();
+}
+
+size_t c_take_shared_with_kj_rc_by_ref(const SharedWithKjRc &shared) {
+  return shared.rc->get();
+}
+
+size_t
+c_take_shared_with_multiple_kj_rcs_by_value(SharedWithMultipleKjRcs shared) {
+  return shared.first->get() + shared.second->get();
+}
+
+size_t c_take_shared_with_multiple_kj_rcs_by_ref(
+    const SharedWithMultipleKjRcs &shared) {
+  return shared.first->get() + shared.second->get();
+}
+
+SharedWithKjRc c_roundtrip_shared_with_kj_rc(SharedWithKjRc shared) {
+  shared.rc->set(shared.rc->get() + 1);
+  return shared;
+}
+
+SharedWithMultipleKjRcs
+c_roundtrip_shared_with_multiple_kj_rcs(SharedWithMultipleKjRcs shared) {
   shared.first->set(shared.first->get() + 10);
   shared.second->set(shared.second->get() + 20);
   return shared;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -2,6 +2,7 @@
 #include "rust/cxx.h"
 
 #include <kj/memory.h>
+#include <kj/refcount.h>
 
 #include <memory>
 #include <string>
@@ -42,6 +43,8 @@ struct Shared;
 struct SharedString;
 struct SharedWithKjOwn;
 struct SharedWithMultipleKjOwns;
+struct SharedWithKjRc;
+struct SharedWithMultipleKjRcs;
 enum class Enum : uint16_t;
 
 class C {
@@ -62,6 +65,16 @@ public:
 private:
   size_t n;
   std::vector<uint8_t> v;
+};
+
+class RcC : public kj::Refcounted {
+public:
+  explicit RcC(size_t n);
+  size_t get() const;
+  void set(size_t n);
+
+private:
+  size_t n;
 };
 
 struct D {
@@ -147,6 +160,23 @@ size_t c_take_shared_with_multiple_kj_owns_by_ref(
 SharedWithKjOwn c_roundtrip_shared_with_kj_own(SharedWithKjOwn shared);
 SharedWithMultipleKjOwns
 c_roundtrip_shared_with_multiple_kj_owns(SharedWithMultipleKjOwns shared);
+kj::Rc<RcC> c_return_kj_rc(size_t n);
+size_t c_sizeof_shared_with_kj_rc();
+size_t c_alignof_shared_with_kj_rc();
+size_t c_sizeof_shared_with_multiple_kj_rcs();
+size_t c_alignof_shared_with_multiple_kj_rcs();
+SharedWithKjRc c_return_shared_with_kj_rc(size_t n);
+SharedWithMultipleKjRcs c_return_shared_with_multiple_kj_rcs(size_t first,
+                                                             size_t second);
+size_t c_take_shared_with_kj_rc_by_value(SharedWithKjRc shared);
+size_t c_take_shared_with_kj_rc_by_ref(const SharedWithKjRc &shared);
+size_t
+c_take_shared_with_multiple_kj_rcs_by_value(SharedWithMultipleKjRcs shared);
+size_t c_take_shared_with_multiple_kj_rcs_by_ref(
+    const SharedWithMultipleKjRcs &shared);
+SharedWithKjRc c_roundtrip_shared_with_kj_rc(SharedWithKjRc shared);
+SharedWithMultipleKjRcs
+c_roundtrip_shared_with_multiple_kj_rcs(SharedWithMultipleKjRcs shared);
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -155,6 +155,59 @@ fn test_kj_own_shared_struct_roundtrip() {
 }
 
 #[test]
+fn test_kj_rc_shared_struct_abi() {
+    assert_eq!(
+        size_of::<ffi::SharedWithKjRc>(),
+        ffi::c_sizeof_shared_with_kj_rc()
+    );
+    assert_eq!(
+        align_of::<ffi::SharedWithKjRc>(),
+        ffi::c_alignof_shared_with_kj_rc()
+    );
+    assert_eq!(
+        size_of::<ffi::SharedWithMultipleKjRcs>(),
+        ffi::c_sizeof_shared_with_multiple_kj_rcs()
+    );
+    assert_eq!(
+        align_of::<ffi::SharedWithMultipleKjRcs>(),
+        ffi::c_alignof_shared_with_multiple_kj_rcs()
+    );
+}
+
+#[test]
+fn test_kj_rc_shared_struct_roundtrip() {
+    let shared = ffi::c_return_shared_with_kj_rc(3030);
+    assert_eq!(3030, ffi::c_take_shared_with_kj_rc_by_ref(&shared));
+    assert_eq!(3030, ffi::c_take_shared_with_kj_rc_by_value(shared));
+
+    let shared = ffi::c_return_shared_with_multiple_kj_rcs(1010, 2020);
+    assert_eq!(
+        3030,
+        ffi::c_take_shared_with_multiple_kj_rcs_by_ref(&shared)
+    );
+    assert_eq!(
+        3030,
+        ffi::c_take_shared_with_multiple_kj_rcs_by_value(shared)
+    );
+
+    let shared = ffi::SharedWithKjRc {
+        rc: ffi::c_return_kj_rc(2020),
+    };
+    let shared = ffi::c_roundtrip_shared_with_kj_rc(shared);
+    assert_eq!(2021, ffi::c_take_shared_with_kj_rc_by_ref(&shared));
+
+    let shared = ffi::SharedWithMultipleKjRcs {
+        first: ffi::c_return_kj_rc(1010),
+        second: ffi::c_return_kj_rc(2020),
+    };
+    let shared = ffi::c_roundtrip_shared_with_multiple_kj_rcs(shared);
+    assert_eq!(
+        3060,
+        ffi::c_take_shared_with_multiple_kj_rcs_by_ref(&shared)
+    );
+}
+
+#[test]
 fn test_c_try_return() {
     assert_eq!((), ffi::c_try_return_void().unwrap());
     assert_eq!(2020, ffi::c_try_return_primitive().unwrap());


### PR DESCRIPTION
Has same binary layout so just works. Bunch of tests to be sure.