### PR TITLE
Update to rules_rust 0.71.2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,12 +5,14 @@ rust_library(
     name = "cxx",
     srcs = glob(["src/**/*.rs"]),
     edition = "2021",
+    link_deps = [
+        ":core",
+    ],
     proc_macro_deps = [
         ":cxxbridge-macro",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":core",
         "@crates.io//:foldhash",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,12 +4,11 @@ module(
     bazel_compatibility = [">=7.2.1"],
 )
 
-bazel_dep(name = "bazel_features", version = "1.42.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "apple_support", version = "2.1.0")
-bazel_dep(name = "rules_rust", version = "0.70.0")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "apple_support", version = "2.6.1")
+bazel_dep(name = "rules_rust", version = "0.71.2")
 
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc")

--- a/kj-rs/BUILD.bazel
+++ b/kj-rs/BUILD.bazel
@@ -22,10 +22,12 @@ rust_library(
     srcs = glob(["*.rs"]),
     compile_data = glob(["*.h"]),
     edition = "2024",
-    visibility = ["//visibility:public"],
-    deps = [
+    link_deps = [
         ":bridge",
         ":kj-rs-lib",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
         "@crates.io//:static_assertions",
         "@workerd-cxx//:cxx",
     ],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -34,11 +34,13 @@ rust_library(
         "ffi/module.rs",
     ],
     edition = "2021",
+    link_deps = [
+        ":impl",
+    ],
     proc_macro_deps = [
         "//:cxxbridge-macro",
     ],
     deps = [
-        ":impl",
         "//:cxx",
         "//kj-rs",
     ],


### PR DESCRIPTION
Use link_deps as needed to avoid deprecation warnings