### PR TITLE
Make RustCopy accept mutable, temporary, and Array inputs

### DIFF
--- a/kj-rs/convert.h
+++ b/kj-rs/convert.h
@@ -239,14 +239,25 @@ inline kj::ArrayPtr<const char> fromImpl(Rust*, const ::rust::Str& str) {
 struct RustCopy {};
 
 /// kjArrayPtr.as<RustCopy>()
+///
+/// Taken by value so it binds equally to const and mutable `kj::ArrayPtr`s, to temporaries (e.g.
+/// `arr.asBytes().as<RustCopy>()`), and to lvalues -- a `kj::ArrayPtr` is just a pointer+size, so
+/// the copy is free. `kj::Decay` drops the element's constness so a `kj::ArrayPtr<const T>` still
+/// yields a `rust::Vec<T>`.
 template <typename T>
-static ::rust::Vec<T> asImpl(RustCopy*, kj::ArrayPtr<const T>& arr) {
-  ::rust::Vec<T> result;
+inline ::rust::Vec<kj::Decay<T>> asImpl(RustCopy*, kj::ArrayPtr<T> arr) {
+  ::rust::Vec<kj::Decay<T>> result;
   result.reserve(arr.size());
   for (auto& t: arr) {
     result.push_back(t);
   }
   return result;
+}
+
+/// kjArray.as<RustCopy>()
+template <typename T>
+inline ::rust::Vec<kj::Decay<T>> asImpl(RustCopy*, const kj::Array<T>& arr) {
+  return asImpl((RustCopy*)nullptr, arr.asPtr());
 }
 
 /// kjStringPtr.as<RustCopy>()

--- a/kj-rs/tests/convert-test.c++
+++ b/kj-rs/tests/convert-test.c++
@@ -221,6 +221,40 @@ KJ_TEST("RustCopy struct - ArrayPtr conversion") {
   KJ_EXPECT(rustVec[2] == 3.3);
 }
 
+KJ_TEST("RustCopy struct - mutable ArrayPtr conversion") {
+  kj::Array<int> kjArray = kj::heapArray<int>({4, 5, 6});
+  kj::ArrayPtr<int> mutablePtr = kjArray.asPtr();
+
+  // A mutable ArrayPtr<T> (not ArrayPtr<const T>) still yields a rust::Vec<T>.
+  auto rustVec = mutablePtr.as<RustCopy>();
+
+  KJ_EXPECT(rustVec.size() == 3);
+  KJ_EXPECT(rustVec[0] == 4);
+  KJ_EXPECT(rustVec[2] == 6);
+}
+
+KJ_TEST("RustCopy struct - temporary ArrayPtr conversion") {
+  kj::Array<kj::byte> kjArray = kj::heapArray<kj::byte>({7, 8, 9});
+
+  // The ArrayPtr produced by asBytes() is a temporary; RustCopy must bind to it.
+  auto rustVec = kjArray.asBytes().as<RustCopy>();
+
+  KJ_EXPECT(rustVec.size() == 3);
+  KJ_EXPECT(rustVec[0] == 7);
+  KJ_EXPECT(rustVec[2] == 9);
+}
+
+KJ_TEST("RustCopy struct - Array conversion") {
+  kj::Array<double> kjArray = kj::heapArray<double>({1.5, 2.5});
+
+  // A kj::Array converts directly, without a manual .asPtr().
+  auto rustVec = kjArray.as<RustCopy>();
+
+  KJ_EXPECT(rustVec.size() == 2);
+  KJ_EXPECT(rustVec[0] == 1.5);
+  KJ_EXPECT(rustVec[1] == 2.5);
+}
+
 KJ_TEST("RustMutable struct - ArrayPtr conversion") {
   kj::Array<int> kjArray = kj::heapArray<int>({100, 200, 300});
   kj::ArrayPtr<int> arrayPtr = kjArray.asPtr();


### PR DESCRIPTION
`kjObject.as<RustCopy>()` only bound `kj::ArrayPtr<const T>&` -- a non-const lvalue reference. Template deduction therefore rejected a mutable `kj::ArrayPtr<T>`, the reference could not bind a temporary (so `arr.asBytes().as<RustCopy>()` failed), and there was no overload for `kj::Array<T>` at all. Callers had to hand-bind an intermediate `kj::ArrayPtr<const T>` lvalue before every owned copy.

Take the `ArrayPtr` by value instead: an `ArrayPtr` is just a pointer+size, so the copy is free, and by-value binds const/mutable, lvalues, and temporaries while still deducing `T`. `kj::Decay` strips the element's constness so `kj::ArrayPtr<const T>` still yields a `rust::Vec<T>`. Add a `kj::Array<T>` overload so arrays convert directly without a manual `.asPtr()`.

Backward compatible: existing `ArrayPtr<const T>` lvalue callers and the `StringPtr`/`ConstString` delegators deduce to the same `rust::Vec<T>`. Adds convert-test coverage for the mutable, temporary, and `kj::Array` cases.