### PR TITLE
Always catch C++ exceptions escaping non-fallible extern "C++" shims

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -814,6 +814,14 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
         out.builtin.trycatch = true;
         writeln!(out, "return ::rust::repr::Result::run([&] {{");
         write!(out, "        ");
+    } else {
+        // A non-fallible extern "C++" function is not allowed to throw, but if
+        // it does anyway (e.g. an unexpected kj::Exception) letting the throw
+        // escape this `noexcept` shim across the Rust FFI boundary is undefined
+        // behavior. Catch it here, adjacent to the call, and convert it into a
+        // deterministic abort rather than risking a segfault during unwinding.
+        writeln!(out, "try {{");
+        write!(out, "    ");
     }
     if indirect_return {
         out.include.new = true;
@@ -864,6 +872,14 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
     writeln!(out, ";");
     if efn.throws {
         writeln!(out, "  }});");
+    } else {
+        writeln!(out, "  }} catch (...) {{");
+        writeln!(
+            out,
+            "    ::rust::repr::Result::terminateWithUncaughtException(\"{}\");",
+            efn.name.to_fully_qualified(),
+        );
+        writeln!(out, "  }}");
     }
     writeln!(out, "}}");
     for arg in &efn.args {

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -816,10 +816,16 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
         write!(out, "        ");
     } else {
         // A non-fallible extern "C++" function is not allowed to throw, but if
-        // it does anyway (e.g. an unexpected kj::Exception) letting the throw
-        // escape this `noexcept` shim across the Rust FFI boundary is undefined
-        // behavior. Catch it here, adjacent to the call, and convert it into a
-        // deterministic abort rather than risking a segfault during unwinding.
+        // it does anyway (e.g. an unexpected kj::Exception) the throw must not
+        // reach the Rust `extern "C"` (nounwind) frame above this shim. This
+        // shim is `noexcept`, so an escape is `std::terminate` on its own -- but
+        // inlining/LTO can fold the shim into its nounwind Rust caller, leaving
+        // no `noexcept` frame to stop the unwind. The exception then propagates
+        // into nounwind Rust land, which is undefined behavior: Rust destructors
+        // are silently skipped (dangling locks/handles) and a delayed SIGSEGV or
+        // unwinder crash follows. Catch it here, adjacent to the call, to force a
+        // deterministic, diagnosable abort. See terminateWithUncaughtException in
+        // include/cxx.h for the full rationale.
         writeln!(out, "try {{");
         write!(out, "    ");
     }

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <initializer_list>
 #include <iosfwd>
@@ -32,6 +33,7 @@
 #define __WORKERD_CXX__
 #endif
 
+#include <kj/debug.h>
 #include <kj/exception.h>
 
 namespace rust {
@@ -82,6 +84,41 @@ struct Result final {
 
   static Result canceled() {
     return {.exception = reinterpret_cast<kj::Exception *>(0x1)};
+  }
+
+  // Invoked from the `catch (...)` handler that generated code wraps around
+  // every non-fallible `extern "C++"` shim. A C++ exception must never unwind
+  // out of such a shim: the shim is `noexcept` and sits directly below Rust
+  // `extern "C"` (nounwind) frames, so an escaping exception is undefined
+  // behavior. In practice the outcome is nondeterministic -- sometimes a clean
+  // `std::terminate`, but often a SIGSEGV when the C++ unwinder walks stack
+  // frames it cannot decode (e.g. JIT-compiled frames with no unwind info).
+  //
+  // Catching the exception here, in the frame adjacent to the throw, keeps
+  // unwinding entirely within decodable C++ frames and converts the failure
+  // into a single deterministic, diagnosable abort. If the error should instead
+  // be delivered to Rust, declare the function as returning `Result<T>` in the
+  // bridge; cxx will then translate the exception into a Rust `Err`.
+  //
+  // Precondition: must be called only from within a `catch (...)` handler,
+  // i.e. while an exception is in flight (this uses a bare `throw;` to inspect
+  // it).
+  [[noreturn]] static void
+  terminateWithUncaughtException(const char *function) {
+    constexpr const char *kMessage =
+        "a C++ exception escaped a non-fallible cxx function across the FFI "
+        "boundary; declare it as returning Result<T> in the #[cxx::bridge] to "
+        "propagate the error to Rust instead of aborting the process";
+    try {
+      throw;
+    } catch (const kj::Exception &e) {
+      KJ_LOG(FATAL, kMessage, function, e);
+    } catch (const std::exception &e) {
+      KJ_LOG(FATAL, kMessage, function, e.what());
+    } catch (...) {
+      KJ_LOG(FATAL, kMessage, function);
+    }
+    ::std::abort();
   }
 
   template <typename Func>

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -87,18 +87,29 @@ struct Result final {
   }
 
   // Invoked from the `catch (...)` handler that generated code wraps around
-  // every non-fallible `extern "C++"` shim. A C++ exception must never unwind
-  // out of such a shim: the shim is `noexcept` and sits directly below Rust
-  // `extern "C"` (nounwind) frames, so an escaping exception is undefined
-  // behavior. In practice the outcome is nondeterministic -- sometimes a clean
-  // `std::terminate`, but often a SIGSEGV when the C++ unwinder walks stack
-  // frames it cannot decode (e.g. JIT-compiled frames with no unwind info).
+  // every non-fallible `extern "C++"` shim.
   //
-  // Catching the exception here, in the frame adjacent to the throw, keeps
-  // unwinding entirely within decodable C++ frames and converts the failure
-  // into a single deterministic, diagnosable abort. If the error should instead
-  // be delivered to Rust, declare the function as returning `Result<T>` in the
-  // bridge; cxx will then translate the exception into a Rust `Err`.
+  // Strictly, an exception escaping the shim itself is well-defined: the shim
+  // is `noexcept`, so the escape is `std::terminate`. The real hazard is one
+  // frame up. The shim sits directly below a Rust `extern "C"` (nounwind)
+  // frame, and above that, often, foreign frames with no unwind info (e.g.
+  // JIT-compiled frames). If the `noexcept` boundary is bypassed -- inlining
+  // or cross-language LTO can fold the tiny shim into its nounwind Rust
+  // caller, so no `noexcept` frame remains to stop the unwind -- the exception
+  // propagates into `nounwind` Rust land. That is genuine undefined behavior:
+  // the optimizer emitted no cleanup landing pads, so Rust destructors are
+  // silently skipped (locks stay held, `Rc`s are not decremented, borrow flags
+  // are not cleared, live handles are left dangling), and the C++ unwinder may
+  // then walk frames it cannot decode. The observed symptom is nondeterministic
+  // -- sometimes a clean abort, but often a *delayed* SIGSEGV once the corrupted
+  // state is next touched, or a crash inside the unwinder itself.
+  //
+  // Catching the exception here, in the frame adjacent to the throw, forces the
+  // failure into a single deterministic, diagnosable abort *before* it can reach
+  // the Rust `extern "C"` frame -- regardless of whether the `noexcept` boundary
+  // survived optimization. If the error should instead be delivered to Rust,
+  // declare the function as returning `Result<T>` in the bridge; cxx will then
+  // translate the exception into a Rust `Err`.
   //
   // Precondition: must be called only from within a `catch (...)` handler,
   // i.e. while an exception is in flight (this uses a bare `throw;` to inspect

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -288,6 +288,12 @@ pub mod ffi {
         fn c_cancel_via_rust_return_primitive() -> Result<usize>;
         fn c_cancel_roundtrip_return_primitive() -> Result<usize>;
 
+        // Intentionally NOT declared `-> Result`, even though it throws. This
+        // exercises the generated always-catch guard, which must convert the
+        // escaping C++ exception into a deterministic abort rather than let it
+        // unwind out of the `noexcept` shim across the FFI boundary (UB).
+        fn c_throw_from_infallible();
+
         fn c_try_return_box() -> Result<Box<R>>;
         unsafe fn c_try_return_ref<'a>(s: &'a String) -> Result<&'a String>;
         unsafe fn c_try_return_str<'a>(s: &'a str) -> Result<&'a str>;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -802,6 +802,10 @@ size_t c_fail_kj_exception_with_details_return_primitive() {
 
 size_t c_cancel_return_primitive() { throw kj::CanceledException{}; }
 
+void c_throw_from_infallible() {
+  throw std::runtime_error("exception from a non-fallible C++ function");
+}
+
 // Call Rust function that panics with CanceledException
 // This will be caught and re-thrown as kj::CanceledException
 size_t c_cancel_via_rust_return_primitive() {
@@ -1194,6 +1198,54 @@ extern "C" const char *cxx_run_test() noexcept {
   rust::String bad_utf8_rstring = rust::String::lossy(bad_utf8_literal);
   rust::String bad_utf16_rstring = rust::String::lossy(bad_utf16_literal);
   ASSERT(bad_utf8_rstring == bad_utf16_rstring);
+
+  // The non-lossy `rust::String` constructors throw `std::invalid_argument`
+  // when given data that is not valid Unicode. This is intended, documented
+  // cxx behavior: a lone (unpaired) UTF-16 surrogate cannot be represented in
+  // a UTF-8-backed `rust::String`. Callers that may receive invalid input must
+  // either use the `lossy` variants or declare their bridge function fallible
+  // (`-> Result<...>`) so cxx wraps the shim in a try/catch. A non-fallible
+  // bridge declaration marks the extern "C" shim `noexcept`, so a throw here
+  // would terminate the process.
+  {
+    // Class B from the URL boundary bug report: a lone low surrogate.
+    const char16_t lone_surrogate[] = {u'a', 0xDC00, 0};
+    bool threw_invalid_argument = false;
+    try {
+      rust::String will_throw(lone_surrogate);
+      (void)will_throw;
+    } catch (const std::invalid_argument &) {
+      threw_invalid_argument = true;
+    }
+    ASSERT(threw_invalid_argument);
+
+    // The explicit-length constructor throws on the same input.
+    threw_invalid_argument = false;
+    try {
+      rust::String will_throw(lone_surrogate, 2);
+      (void)will_throw;
+    } catch (const std::invalid_argument &) {
+      threw_invalid_argument = true;
+    }
+    ASSERT(threw_invalid_argument);
+
+    // The lossy variant is noexcept and substitutes U+FFFD (replacement char)
+    // for the lone surrogate rather than throwing.
+    rust::String lossy_ok = rust::String::lossy(lone_surrogate);
+    const char16_t expected_utf16[] = {u'a', 0xFFFD, 0};
+    ASSERT(lossy_ok == rust::String(expected_utf16));
+
+    // A properly paired surrogate (U+10000) is valid UTF-16 and must not throw.
+    const char16_t paired_surrogate[] = {0xD800, 0xDC00, 0};
+    bool paired_ok = true;
+    try {
+      rust::String valid(paired_surrogate);
+      (void)valid;
+    } catch (const std::invalid_argument &) {
+      paired_ok = false;
+    }
+    ASSERT(paired_ok);
+  }
 
   const char *ascii_literal = "42";
   const char *latin1_literal = "\xff";

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -288,6 +288,7 @@ size_t c_fail_kj_exception_with_details_return_primitive();
 size_t c_cancel_return_primitive();
 size_t c_cancel_via_rust_return_primitive();
 size_t c_cancel_roundtrip_return_primitive();
+void c_throw_from_infallible();
 rust::Box<R> c_try_return_box();
 const rust::String &c_try_return_ref(const rust::String &);
 rust::Str c_try_return_str(rust::Str);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -329,6 +329,60 @@ fn test_c_try_return() {
     assert_eq!("2020", &*ffi::c_try_return_unique_ptr_string().unwrap());
 }
 
+// A C++ function that is NOT declared `-> Result` but throws anyway must not
+// invoke undefined behavior across the FFI boundary. The generated shim wraps
+// the call in `catch (...)` and converts the escaping exception into a
+// deterministic `abort()` (SIGABRT) with a diagnostic -- never a segfault and
+// never a silent success.
+//
+// The throw aborts the process, so it is exercised in a re-exec'd child and the
+// parent inspects the child's termination.
+#[cfg(unix)]
+#[test]
+fn test_infallible_cxx_exception_aborts() {
+    use std::os::unix::process::ExitStatusExt;
+
+    const CHILD_ENV: &str = "CXX_TEST_INFALLIBLE_THROW_CHILD";
+    const SIGABRT: i32 = 6;
+
+    // Child mode: trigger the throw. This must abort the process from inside
+    // the generated shim's catch handler and must never return here.
+    if std::env::var_os(CHILD_ENV).is_some() {
+        ffi::c_throw_from_infallible();
+        // If we reach this line the guard failed to abort.
+        eprintln!("BUG: c_throw_from_infallible returned without aborting");
+        std::process::exit(0);
+    }
+
+    // Parent mode: re-run just this test in a child process with the env set.
+    let exe = std::env::current_exe().expect("current_exe");
+    let output = std::process::Command::new(exe)
+        .args(["--exact", "test_infallible_cxx_exception_aborts"])
+        .env(CHILD_ENV, "1")
+        .output()
+        .expect("spawn child");
+
+    let status = output.status;
+    assert!(
+        status.code().is_none(),
+        "child should have been killed by a signal (abort), but exited with {status:?}"
+    );
+    assert_eq!(
+        status.signal(),
+        Some(SIGABRT),
+        "child must abort deterministically (SIGABRT), not e.g. SIGSEGV; got signal {:?}\nstderr:\n{}",
+        status.signal(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // The abort should carry the diagnostic pointing at the fix.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("non-fallible") && stderr.contains("Result<T>"),
+        "expected FFI-boundary diagnostic in child stderr, got:\n{stderr}"
+    );
+}
+
 #[test]
 fn test_c_take() {
     let unique_ptr = ffi::c_return_unique_ptr();


### PR DESCRIPTION
## Problem

A C++ function declared in a `#[cxx::bridge]` **without** `-> Result<T>` is assumed infallible, and its generated `extern "C"` shim is marked `noexcept`. Any unexpected exception unwinds out of the `noexcept` shim, which sits directly below Rust `extern "C"` (nounwind) frames. That is **undefined behavior**. In practice the observed outcome is nondeterministic:

- sometimes a clean `std::terminate` → **SIGABRT**, but
- often a **SIGSEGV**, when the C++ two-phase unwinder's phase-1 *search* walks stack frames it cannot decode (e.g. V8 JIT-compiled JS frames that have no DWARF/`.eh_frame` info). The crash happens on the C++ side of the boundary, so no choice of Rust FFI ABI or panic mode can prevent it.

## Fix

Wrap the body of every **non-fallible** `extern "C++"` shim in `try { ... } catch (...) { ... }` and convert an escaping exception into a single **deterministic, diagnosable abort** via a new `rust::repr::Result::terminateWithUncaughtException` helper. Because the catch handler is in the frame **adjacent to the throw**, unwinding never leaves decodable C++ frames and the segfault path is eliminated.

- Zero-cost C++ EH means **no happy-path cost** and **no public signature changes**.
- Fallible functions (`-> Result<T>`) are unaffected and keep translating exceptions into a Rust `Err`.
- The abort message points at the remedy: declare the function fallible so cxx propagates the error to Rust.

### Generated code (non-fallible)
```cpp
void cxxbridge1$c_void_fn() noexcept {
  void (*c_void_fn$)() = ::c_void_fn;
  try {
    c_void_fn$();
  } catch (...) {
    ::rust::repr::Result::terminateWithUncaughtException("::c_void_fn");
  }
}
```

## Motivation for the change

I encountered this when porting node-url to Rust - a JSG function threw an exception and was not marked as returning `Result`, causing a segfault. This is an easy mistake to make, and something that will likely happen many more times during the migration.

Another option I considered was to propagate C++ exceptions through the Rust stack when they aren't caught. I did not go for this solution for two reasons:
1. It breaks the assumption in existing Rust code that exceptions are always translated to `Result<T>`. 
2. This approach only masks bugs. In my motivating node-url case, there actually was error handling in place, but it was __in Rust__, not C++. Propagating the exception would have skipped the intended error handling path. The result would likely be an uncaught exception higher up in the C++ stack. It would be much better to catch the error where it actually happened, and abort early.  

## Tests

- `test_infallible_cxx_exception_aborts` re-execs the test binary to call a non-fallible throwing function and asserts the child dies with **SIGABRT** (not SIGSEGV, not silent success) and emits the diagnostic string.
- Adds `rust::String` UTF-16 constructor tests documenting that the non-lossy constructor throws on lone surrogates while `lossy` substitutes U+FFFD — a library-internal source of such throws.

`bazel test //...`, `bazel build --config=clippy //...`, and `just format` all pass.