### PR TITLE
Turn C++ exceptions into panics instead of aborting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,14 @@ Async tests require a `kj::EventLoop` and are driven from C++ using `KJ_TEST`, n
 
 FFI declarations live in `#[cxx::bridge]` blocks in `lib.rs` files. The proc macro generates C++ headers (`lib.rs.h`) that C++ code includes. Marking a function `async` in `extern "Rust"` makes it return `kj::Promise<T>` on the C++ side; marking one `async` in `extern "C++"` makes it return `impl Future` on the Rust side.
 
+### Exceptions and panics across the bridge
+
+An exception or panic must never terminate the process, so every generated shim reports failure through its return value (`rust::repr::Result` / `cxx::private::Result`, a tagged `kj::Exception*`) and any actual return value travels through an out parameter:
+
+- `extern "Rust"` functions: a panic is caught (`catch_unwind`/`try_unwind` in `src/unwind.rs`) and rethrown in C++ as a `kj::Exception`.
+- `extern "C++"` functions: the shim catches every exception (`rust::repr::Result::run` in `include/cxx.h`). Signatures declared `-> Result<T>` produce `Err`; infallible signatures panic instead (`Result::panic_on_exception` in `src/result.rs`).
+- `kj::CanceledException` is preserved in both directions as a panic carrying a `cxx::CanceledException` payload.
+
 ### Async FFI (kj-rs/)
 
 The `kj-rs/` directory bridges KJ promises and Rust futures:

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,6 +1,11 @@
 Important changes:
 
-- `no-abort` replacing panic with exception handling.
+- `no-abort` replacing panic with exception handling. Every ffi function reports failure
+    through its return value in both directions: an `extern "Rust"` function which panics
+    reports a `kj::Exception` to C++, and an `extern "C++"` function which throws reports
+    the exception to Rust, which panics if the signature has no `Result`. Neither
+    direction is allowed to terminate the process, so no ffi shim is truly `noexcept` and
+    every return value travels through an out parameter.
 - `require lifetime annotations on all returned references` - `no-abort` dependency
 
 Misc changes:

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -740,12 +740,12 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
     out.set_namespace(&efn.name.namespace);
     out.begin_block(Block::ExternC);
     begin_function_definition(out);
-    if efn.throws {
-        out.builtin.ptr_len = true;
-        write!(out, "::rust::repr::Result ");
-    } else {
-        write_extern_return_type_space(out, &efn.ret);
-    }
+    // C++ functions always return a Result: an exception must never be allowed to
+    // escape through the extern "C" boundary (that would terminate the process), so
+    // the shim catches everything and hands the exception to Rust, which turns it
+    // into an `Err` for fallible signatures and a panic for infallible ones.
+    out.builtin.ptr_len = true;
+    write!(out, "::rust::repr::Result ");
     let mangled = mangle::extern_fn(efn, out.types);
     write!(out, "{}(", mangled);
     if let Some(receiver) = &efn.receiver {
@@ -765,7 +765,7 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
         }
         write_cxx_shim_sig_arg(out, arg);
     }
-    let indirect_return = indirect_return(efn, out.types);
+    let indirect_return = indirect_return(efn);
     if indirect_return {
         if !efn.args.is_empty() || efn.receiver.is_some() {
             write!(out, ", ");
@@ -809,32 +809,17 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
     }
     writeln!(out, ";");
     write!(out, "  ");
-    if efn.throws {
-        out.builtin.ptr_len = true;
-        out.builtin.trycatch = true;
-        writeln!(out, "return ::rust::repr::Result::run([&] {{");
-        write!(out, "        ");
-    }
+    out.builtin.trycatch = true;
+    writeln!(out, "return ::rust::repr::Result::run([&] {{");
+    write!(out, "        ");
     if indirect_return {
         out.include.new = true;
         write!(out, "new (return$) ");
         write_indirect_return_type(out, efn.ret.as_ref().unwrap());
         write!(out, "(");
-    } else if efn.ret.is_some() {
-        write!(out, "return ");
     }
     match &efn.ret {
         Some(Type::Ref(_)) => write!(out, "&"),
-        Some(Type::Str(_)) if !indirect_return => {
-            out.builtin.rust_str_repr = true;
-            write!(out, "::rust::impl<::rust::Str>::repr(");
-        }
-        Some(ty @ Type::SliceRef(_)) if !indirect_return => {
-            out.builtin.rust_slice_repr = true;
-            write!(out, "::rust::impl<");
-            write_type(out, ty);
-            write!(out, ">::repr(");
-        }
         Some(Type::KjDate(_)) => {
             write!(out, "::kj_rs::repr::toNanos(");
         }
@@ -855,16 +840,13 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
         Some(Type::RustBox(_)) => write!(out, ".into_raw()"),
         Some(Type::UniquePtr(_)) => write!(out, ".release()"),
         Some(Type::KjDate(_)) => write!(out, ")"),
-        Some(Type::Str(_) | Type::SliceRef(_)) if !indirect_return => write!(out, ")"),
         _ => {}
     }
     if indirect_return {
         write!(out, ")");
     }
     writeln!(out, ";");
-    if efn.throws {
-        writeln!(out, "  }});");
-    }
+    writeln!(out, "  }});");
     writeln!(out, "}}");
     for arg in &efn.args {
         if let Type::Fn(f) = &arg.ty {
@@ -1200,10 +1182,10 @@ fn write_return_type(out: &mut OutFile, ty: &Option<Type>) {
     }
 }
 
-fn indirect_return(sig: &Signature, types: &Types) -> bool {
-    sig.ret
-        .as_ref()
-        .is_some_and(|ret| sig.throws || types.needs_indirect_abi(ret))
+// C++ functions always report exceptions through their return value, so any actual
+// return value has to travel through an out parameter.
+fn indirect_return(sig: &Signature) -> bool {
+    sig.ret.is_some()
 }
 
 fn write_indirect_return_type(out: &mut OutFile, ty: &Type) {
@@ -1220,6 +1202,11 @@ fn write_indirect_return_type(out: &mut OutFile, ty: &Type) {
             write!(out, "*");
         }
         Type::Future(_) => write!(out, "kj_rs::repr::KjPromiseNodeImpl"),
+        // kj::Date travels across the boundary as nanoseconds since the unix epoch.
+        Type::KjDate(_) => {
+            out.include.cstdint = true;
+            write!(out, "::std::int64_t");
+        }
         _ => write_type(out, ty),
     }
 }
@@ -1230,31 +1217,6 @@ fn write_indirect_return_type_space(out: &mut OutFile, ty: &Type) {
         Type::RustBox(_) | Type::UniquePtr(_) | Type::Ref(_) => {}
         Type::Str(_) | Type::SliceRef(_) => write!(out, " "),
         _ => write_space_after_type(out, ty),
-    }
-}
-
-fn write_extern_return_type_space(out: &mut OutFile, ty: &Option<Type>) {
-    match ty {
-        Some(Type::RustBox(ty) | Type::UniquePtr(ty)) => {
-            write_type_space(out, &ty.inner);
-            write!(out, "*");
-        }
-        Some(Type::Ref(ty)) => {
-            write_type_space(out, &ty.inner);
-            if !ty.mutable {
-                write!(out, "const ");
-            }
-            write!(out, "*");
-        }
-        Some(Type::Str(_) | Type::SliceRef(_)) => {
-            out.builtin.repr_fat = true;
-            write!(out, "::rust::repr::Fat ");
-        }
-        Some(Type::KjDate(_)) => {
-            write!(out, "::std::int64_t ");
-        }
-        Some(ty) if out.types.needs_indirect_abi(ty) => write!(out, "void "),
-        _ => write_return_type(out, ty),
     }
 }
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -497,13 +497,11 @@ fn expand_cxx_function_decl(efn: &ExternFn, types: &Types) -> TokenStream {
         }
     });
     let all_args = receiver.chain(args);
-    let ret = if efn.throws {
-        quote!(-> ::cxx::private::Result)
-    } else {
-        expand_extern_return_type(&efn.ret, types, true)
-    };
+    // C++ functions always return a Result: an exception must never escape through the
+    // extern "C" boundary, so the C++ shim catches it and reports it here instead.
+    let ret = quote!(-> ::cxx::private::Result);
     let mut outparam = None;
-    if indirect_return(efn, types) {
+    if indirect_return(efn) {
         let ret = expand_extern_type(efn.ret.as_ref().unwrap(), types, true);
         outparam = Some(quote!(__return: *mut #ret));
     }
@@ -543,7 +541,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
     } else {
         expand_return_type(&efn.ret)
     };
-    let indirect_return = indirect_return(efn, types);
+    let indirect_return = indirect_return(efn);
     let receiver_var = efn
         .receiver
         .iter()
@@ -653,8 +651,10 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                 #local_name(#(#vars,)* __return.as_mut_ptr()).into_result()?;
             }
         } else {
+            // An infallible signature cannot report the exception to its caller, so
+            // turn it into a panic rather than letting the process abort.
             quote_spanned! {span=>
-                #local_name(#(#vars,)* __return.as_mut_ptr());
+                #local_name(#(#vars,)* __return.as_mut_ptr()).panic_on_exception();
             }
         });
         quote_spanned!(span=> __return.assume_init())
@@ -664,7 +664,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
         }
     } else {
         quote_spanned! {span=>
-            #local_name(#(#vars),*)
+            #local_name(#(#vars),*).panic_on_exception()
         }
     };
     let mut expr;
@@ -2011,10 +2011,10 @@ fn expand_return_type(ret: &Option<Type>) -> TokenStream {
     }
 }
 
-fn indirect_return(sig: &Signature, types: &Types) -> bool {
-    sig.ret
-        .as_ref()
-        .is_some_and(|ret| sig.throws || types.needs_indirect_abi(ret))
+// C++ functions always report exceptions through their return value, so any actual
+// return value has to travel through an out parameter.
+fn indirect_return(sig: &Signature) -> bool {
+    sig.ret.is_some()
 }
 
 fn expand_extern_type(ty: &Type, types: &Types, proper: bool) -> TokenStream {
@@ -2094,15 +2094,6 @@ fn expand_extern_type(ty: &Type, types: &Types, proper: bool) -> TokenStream {
         }
         _ => quote!(#ty),
     }
-}
-
-fn expand_extern_return_type(ret: &Option<Type>, types: &Types, proper: bool) -> TokenStream {
-    let ret = match ret {
-        Some(ret) if !types.needs_indirect_abi(ret) => ret,
-        _ => return TokenStream::new(),
-    };
-    let ty = expand_extern_type(ret, types, proper);
-    quote!(-> #ty)
 }
 
 // #UnsafeExtern extern "C" {...}

--- a/src/result.rs
+++ b/src/result.rs
@@ -38,6 +38,41 @@ pub(crate) mod repr {
             }
         }
 
+        /// Turn a C++ exception into a Rust panic.
+        ///
+        /// Called by generated code after invoking an `extern "C++"` function which is
+        /// not declared to return a `Result`. Such a signature has no way of reporting
+        /// an exception to its caller, so the exception is converted into a panic. This
+        /// is what keeps a throwing C++ function from terminating the process: the panic
+        /// is caught again at the next `extern "Rust"` boundary and rethrown there as a
+        /// `kj::Exception`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the C++ function threw an exception, or with a `CanceledException`
+        /// payload if it threw `kj::CanceledException`.
+        #[track_caller]
+        pub fn panic_on_exception(self) {
+            if let Err(exception) = self.into_result() {
+                // Exceptions which did not originate from a KJ macro have no throw site.
+                let thrown_at = if exception.line() > 0 {
+                    alloc::format!(
+                        " at {}:{}",
+                        exception.file().to_str().unwrap_or("(unknown file)"),
+                        exception.line(),
+                    )
+                } else {
+                    alloc::string::String::new()
+                };
+                panic!(
+                    "C++ exception in infallible ffi function{}: {:?}: {}",
+                    thrown_at,
+                    exception.r#type(),
+                    exception.what(),
+                );
+            }
+        }
+
         /// Convert into a `Result`.
         ///
         /// # Panics

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -95,7 +95,12 @@ fn test_extern_c_function() {
     let output = str::from_utf8(&generated.implementation).unwrap();
     // To avoid continual breakage we won't test every byte.
     // Let's look for the major features.
-    assert!(output.contains("void cxxbridge1$do_cpp_thing(::rust::Str foo)"));
+    assert!(
+        output.contains("::rust::repr::Result cxxbridge1$do_cpp_thing(::rust::Str foo) noexcept")
+    );
+    // The shim must catch every exception: letting one escape the extern "C" boundary
+    // would terminate the process.
+    assert!(output.contains("return ::rust::repr::Result::run("));
 }
 
 #[test]
@@ -107,7 +112,9 @@ fn test_impl_annotation() {
     let source = BRIDGE0.parse().unwrap();
     let generated = generate_header_and_cc(source, &opt).unwrap();
     let output = str::from_utf8(&generated.implementation).unwrap();
-    assert!(output.contains("ANNOTATION void cxxbridge1$do_cpp_thing(::rust::Str foo)"));
+    assert!(
+        output.contains("ANNOTATION ::rust::repr::Result cxxbridge1$do_cpp_thing(::rust::Str foo)")
+    );
 }
 
 #[test]

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -288,6 +288,16 @@ pub mod ffi {
         fn c_cancel_via_rust_return_primitive() -> Result<usize>;
         fn c_cancel_roundtrip_return_primitive() -> Result<usize>;
 
+        // These signatures are infallible, but the C++ implementations throw.
+        // The exception has to become a panic; it must not abort the process.
+        fn c_infallible_fail_void();
+        fn c_infallible_fail_primitive() -> usize;
+        fn c_infallible_fail_kj_exception_disconnected() -> usize;
+        fn c_infallible_fail_rust_string() -> String;
+        fn c_infallible_fail_foreign_exception() -> usize;
+        fn c_infallible_cancel() -> usize;
+        fn c_infallible_fail_roundtrip() -> usize;
+
         fn c_try_return_box() -> Result<Box<R>>;
         unsafe fn c_try_return_ref<'a>(s: &'a String) -> Result<&'a String>;
         unsafe fn c_try_return_str<'a>(s: &'a str) -> Result<&'a str>;
@@ -306,6 +316,7 @@ pub mod ffi {
         unsafe fn getMut<'a>(self: Pin<&'a mut C>) -> &'a mut usize;
         fn set_succeed(self: Pin<&mut C>, n: usize) -> Result<usize>;
         fn get_fail(self: Pin<&mut C>) -> Result<usize>;
+        fn get_fail_infallible(self: Pin<&mut C>) -> usize;
         fn c_method_on_shared(self: &Shared) -> usize;
         unsafe fn c_method_ref_on_shared<'a>(self: &'a Shared) -> &'a usize;
         unsafe fn c_method_mut_on_shared<'a>(self: &'a mut Shared) -> &'a mut usize;
@@ -433,6 +444,7 @@ pub mod ffi {
         fn r_result_kj_exception_with_details_return_primitive() -> Result<usize>;
         fn r_cancel_panic_test();
         fn r_call_c_cancel_return_primitive();
+        fn r_call_c_infallible_fail_primitive();
         fn r_cancel_via_cpp_return_primitive() -> Result<usize>;
         fn r_cancel_roundtrip_return_primitive() -> Result<usize>;
 
@@ -822,6 +834,14 @@ fn r_cancel_panic_test() {
 // This should result in a panic that propagates back
 fn r_call_c_cancel_return_primitive() {
     let _result = ffi::c_cancel_return_primitive();
+    unreachable!();
+}
+
+// Calling an infallible C++ function which throws panics. Neither this function
+// nor the C++ shim it calls declares a Result, so the exception has to travel
+// back to C++ as a panic converted at this function's own ffi boundary.
+fn r_call_c_infallible_fail_primitive() {
+    let _result = ffi::c_infallible_fail_primitive();
     unreachable!();
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -57,6 +57,10 @@ size_t C::set_succeed(size_t n) { return this->set(n); }
 
 size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
 
+size_t C::get_fail_infallible() {
+  kj::throwFatalException(KJ_EXCEPTION(FAILED, "infallible method failure"));
+}
+
 RcC::RcC(size_t n) : n(n) {}
 
 size_t RcC::get() const { return this->n; }
@@ -816,6 +820,43 @@ size_t c_cancel_roundtrip_return_primitive() {
   return 2020; // Should not reach here
 }
 
+// The functions below throw even though their bridge signature is infallible.
+// Rust cannot report the exception to its caller, so it panics instead. None of
+// them may terminate the process.
+void c_infallible_fail_void() {
+  kj::throwFatalException(KJ_EXCEPTION(FAILED, "infallible void failure"));
+}
+
+size_t c_infallible_fail_primitive() {
+  throw std::logic_error("infallible logic error");
+}
+
+size_t c_infallible_fail_kj_exception_disconnected() {
+  kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "infallible disconnect"));
+}
+
+rust::String c_infallible_fail_rust_string() {
+  kj::throwFatalException(KJ_EXCEPTION(FAILED, "infallible string failure"));
+}
+
+// Neither a kj::Exception nor a std::exception. This is the shape of
+// workerd's jsg::JsExceptionThrown, which used to abort the process here.
+namespace {
+struct ForeignException {};
+} // namespace
+
+size_t c_infallible_fail_foreign_exception() { throw ForeignException{}; }
+
+size_t c_infallible_cancel() { throw kj::CanceledException{}; }
+
+// Test C++->Rust->C++ roundtrip of an exception through an infallible bridge
+// function on both sides: the exception becomes a panic in Rust and is rethrown
+// as a kj::Exception when it crosses back into C++.
+size_t c_infallible_fail_roundtrip() {
+  r_call_c_infallible_fail_primitive();
+  return 2020; // Should not reach here
+}
+
 rust::Box<R> c_try_return_box() { return c_return_box(); }
 
 const rust::String &c_try_return_ref(const rust::String &s) { return s; }
@@ -1313,6 +1354,18 @@ extern "C" const char *cxx_run_test() noexcept {
     // Expected: CanceledException should propagate from C++ through Rust back to C++
   } catch (...) {
     KJ_FAIL_ASSERT("Unexpected exception in roundtrip test",
+                   kj::getCaughtExceptionAsKj());
+  }
+
+  // An exception thrown by an infallible C++ function becomes a panic in Rust,
+  // which turns back into a kj::Exception here rather than aborting.
+  try {
+    r_call_c_infallible_fail_primitive();
+    ASSERT(false); // Should not reach here
+  } catch (const kj::Exception &e) {
+    ASSERT(e.getDescription().contains("infallible logic error"));
+  } catch (...) {
+    KJ_FAIL_ASSERT("Unexpected exception in infallible failure test",
                    kj::getCaughtExceptionAsKj());
   }
 

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -60,6 +60,7 @@ public:
   size_t &getMut();
   size_t set_succeed(size_t n);
   size_t get_fail();
+  size_t get_fail_infallible();
   const std::vector<uint8_t> &get_v() const;
   std::vector<uint8_t> &get_v();
   rust::String cOverloadedMethod(int32_t x) const;
@@ -288,6 +289,16 @@ size_t c_fail_kj_exception_with_details_return_primitive();
 size_t c_cancel_return_primitive();
 size_t c_cancel_via_rust_return_primitive();
 size_t c_cancel_roundtrip_return_primitive();
+
+// Functions which throw even though their bridge signature is infallible. Their
+// exceptions must turn into Rust panics rather than terminating the process.
+void c_infallible_fail_void();
+size_t c_infallible_fail_primitive();
+size_t c_infallible_fail_kj_exception_disconnected();
+rust::String c_infallible_fail_rust_string();
+size_t c_infallible_fail_foreign_exception();
+size_t c_infallible_cancel();
+size_t c_infallible_fail_roundtrip();
 rust::Box<R> c_try_return_box();
 const rust::String &c_try_return_ref(const rust::String &);
 rust::Str c_try_return_str(rust::Str);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -617,6 +617,84 @@ fn test_unwind_safe() {
     require_ref_unwind_safe::<ffi::C>();
 }
 
+/// Runs `f`, which is expected to panic, and returns the panic message.
+fn expect_panic_message<F: FnOnce() + UnwindSafe>(f: F) -> String {
+    let payload = panic::catch_unwind(f).expect_err("expected a panic");
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else {
+        panic!("panic payload was not a message");
+    }
+}
+
+// An `extern "C++"` function which is not declared to return a Result has no way of
+// reporting an exception to its caller. The exception must become a panic; letting it
+// escape the extern "C" boundary would terminate the process.
+#[test]
+fn test_infallible_cxx_function_throws() {
+    let message = expect_panic_message(ffi::c_infallible_fail_void);
+    assert!(message.contains("infallible void failure"), "{message}");
+
+    let message = expect_panic_message(|| {
+        let _ = ffi::c_infallible_fail_primitive();
+    });
+    assert!(
+        message.contains("std::exception: infallible logic error"),
+        "{message}"
+    );
+
+    // The kj::Exception type is preserved in the panic message.
+    let message = expect_panic_message(|| {
+        let _ = ffi::c_infallible_fail_kj_exception_disconnected();
+    });
+    assert!(message.contains("Disconnected"), "{message}");
+    assert!(message.contains("infallible disconnect"), "{message}");
+
+    // Return type which travels through an out parameter.
+    let message = expect_panic_message(|| {
+        let _ = ffi::c_infallible_fail_rust_string();
+    });
+    assert!(message.contains("infallible string failure"), "{message}");
+
+    // Neither a kj::Exception nor a std::exception, like jsg::JsExceptionThrown.
+    let message = expect_panic_message(|| {
+        let _ = ffi::c_infallible_fail_foreign_exception();
+    });
+    assert!(message.contains("unknown non-KJ exception"), "{message}");
+
+    // Member function with a receiver.
+    let message = expect_panic_message(|| {
+        let mut unique_ptr = ffi::c_return_unique_ptr();
+        let _ = unique_ptr.pin_mut().get_fail_infallible();
+    });
+    assert!(message.contains("infallible method failure"), "{message}");
+}
+
+#[test]
+fn test_infallible_cxx_function_cancellation() {
+    let payload = panic::catch_unwind(|| {
+        let _ = ffi::c_infallible_cancel();
+    })
+    .expect_err("expected a panic");
+    assert!(
+        payload.downcast_ref::<cxx::CanceledException>().is_some(),
+        "expected panic payload to be CanceledException"
+    );
+}
+
+// C++ -> Rust -> C++ -> Rust, without a Result anywhere along the way. The exception
+// becomes a panic in Rust, a kj::Exception again when it reenters C++, and finally a
+// panic once more.
+#[test]
+fn test_infallible_exception_roundtrip() {
+    let message = expect_panic_message(|| {
+        let _ = ffi::c_infallible_fail_roundtrip();
+    });
+    assert!(message.contains("infallible logic error"), "{message}");
+}
+
 #[test]
 fn test_rust_to_cpp_cancellation() {
     // Test Rust->C++ cancellation: Rust calls C++ function that throws CanceledException


### PR DESCRIPTION
## Problem

An `extern "C++"` function that is not declared to return a `Result` had no way to report an exception. The generated shim called the C++ function directly and was `noexcept`, so throwing terminated the process.

## Change

Give the C++ direction the same channel the Rust direction has had since `no-abort` (#2):

- `gen/src/write.rs` — every cxx shim returns `::rust::repr::Result` and wraps the call in `::rust::repr::Result::run([&]{...})`, which catches `kj::Exception`, `kj::CanceledException`, `std::exception` and `...`. Consequently `indirect_return` is now just `ret.is_some()`: any actual return value travels through an out parameter. Dropped the now-dead direct-return paths (`write_extern_return_type_space`, the `rust::impl<Str>::repr` fat-pointer returns) and taught `write_indirect_return_type` that `KjDate` crosses as `::std::int64_t` nanos, not `kj::Date`.
- `macro/src/expand.rs` — the Rust declaration always returns `::cxx::private::Result`. Fallible signatures keep `.into_result()?`; infallible ones call `.panic_on_exception()`.
- `src/result.rs` — new `Result::panic_on_exception`. `#[track_caller]`, so the panic points at the bridge declaration. `kj::CanceledException` still surfaces as a `CanceledException` panic payload via the existing `into_result`, so cancellation semantics are unchanged.

The panic is caught and rethrown as a `kj::Exception` at the next `extern "Rust"` boundary, so an exception can now cross infallible Rust frames in both directions:

```
thread '...' panicked at tests/ffi/lib.rs:295:66:
C++ exception in infallible ffi function at tests/ffi/tests.cc:835: Disconnected: infallible disconnect
```

## Tests

`tests/ffi` gains throwing-but-infallible functions covering void return, primitive return, out-param return (`String`), a non-`Failed` `kj::Exception` type, a member function with a receiver, `kj::CanceledException`, and an exception that is neither a `kj::Exception` nor a `std::exception` — the `jsg::JsExceptionThrown` shape from the bug report, which now reports `"unknown non-KJ exception"` instead of `SIGABRT`. Plus a C++ -> Rust -> C++ -> Rust roundtrip asserted from both sides.

`bazel test //...`, `--config=asan`, `--config=clippy` and `just format` are clean.

## Not fixed here

Panics on the async poll path still abort: `RustFuture::poll` / `RustInfallibleFuture::poll` (`kj-rs/future.rs:76`, `:113`) are `extern "C"` with no `catch_unwind`, so a throw from an infallible C++ call *inside a future* still dies (as does any `unwrap()` in async Rust today — pre-existing, and not made worse by this change). `FuturePollStatus::Error` is the right channel and already works for infallible futures, but cancellation has no representation there: `Result`'s canceled tag is the sentinel `0x1`, and `FuturePoller` does `addException(kj::mv(*error)); delete error;`. That needs a new poll status and a decision about what a canceled Rust future means to a KJ awaiter, so it is left as a follow-up.

## Compatibility

This is an ABI change for every non-`Result` bridge function. Both sides are generated, so dependents only need a rebuild against the new workerd-cxx, no source changes.